### PR TITLE
Add Exception to Statistics Object

### DIFF
--- a/src/PollyTick/BookKeepingObserver.cs
+++ b/src/PollyTick/BookKeepingObserver.cs
@@ -31,7 +31,7 @@ namespace PollyTick
             int executions = _executions;
             int exceptions = _exceptions;
             long ticks = Interlocked.Read(ref _totalTimespanTicks);
-            return new Statistics(executions, exceptions, TimeSpan.FromTicks(ticks));
+            return new Statistics(executions, exceptions, TimeSpan.FromTicks(ticks), LastException);
         }
 
         /// <summary>

--- a/src/PollyTick/Statistics.cs
+++ b/src/PollyTick/Statistics.cs
@@ -9,11 +9,12 @@ namespace PollyTick
     /// </summary>
     public class Statistics
     {
-        public Statistics(int executions, int exceptions, TimeSpan elapsed)
+        public Statistics(int executions, int exceptions, TimeSpan elapsed, Exception finalException)
         {
             Executions = executions;
             Exceptions = exceptions;
             Elapsed = elapsed;
+			FinalException = finalException;
         }
 
         /// <summary>
@@ -32,6 +33,11 @@ namespace PollyTick
         ///   The total elapsed time for all executions.
         /// </summary>
         public TimeSpan Elapsed { get; }
+
+		/// <summary>
+		///   The final exception seen by this statistics, if any.
+		/// </summary>
+		public Exception FinalException { get; }
     }
 
     /// <summary>
@@ -39,8 +45,8 @@ namespace PollyTick
     /// </summary>
     public class Statistics<T> : Statistics
     {
-        public Statistics(int executions, int exceptions, TimeSpan elapsed, T result)
-            : base(executions, exceptions, elapsed)
+        public Statistics(int executions, int exceptions, TimeSpan elapsed, Exception finalException, T result)
+            : base(executions, exceptions, elapsed, finalException)
         {
             Result = result;
         }

--- a/src/PollyTick/TickerInstanceBase.cs
+++ b/src/PollyTick/TickerInstanceBase.cs
@@ -32,7 +32,7 @@ namespace PollyTick
             IStatisticsObserver observer)
         {
             var failures = result.Outcome == OutcomeType.Successful ? 0 : 1;
-            var stats = new Statistics<TResult>(1, failures, sw.Elapsed, result.Result);
+            var stats = new Statistics<TResult>(1, failures, sw.Elapsed, result.FinalException, result.Result);
 
             if (result.FinalException != null)
             {
@@ -52,6 +52,7 @@ namespace PollyTick
             var sw = Stopwatch.StartNew();
             int exceptions = 0;
             T result = default(T);
+			Exception capturedException = null;
             try
             {
                 result = action();
@@ -60,13 +61,14 @@ namespace PollyTick
             catch (Exception e)
             {
                 OnException(e, observer);
+				capturedException = e;
                 exceptions++;
                 throw;
             }
             finally
             {
                 sw.Stop();
-                var stats = new Statistics<T>(1, exceptions, sw.Elapsed, result);
+                var stats = new Statistics<T>(1, exceptions, sw.Elapsed, capturedException, result);
                 OnExecute(stats, observer);
             }
         }
@@ -82,6 +84,7 @@ namespace PollyTick
             var sw = Stopwatch.StartNew();
             var exceptions = 0;
             T result = default(T);
+			Exception capturedException = null;
             try
             {
                 result = await action(token);
@@ -90,13 +93,14 @@ namespace PollyTick
             catch (Exception e)
             {
                 OnException(e, observer);
+				capturedException = e;
                 exceptions++;
                 throw;
             }
             finally
             {
                 sw.Stop();
-                var stats = new Statistics<T>(1, exceptions, sw.Elapsed, result);
+                var stats = new Statistics<T>(1, exceptions, sw.Elapsed, capturedException, result);
                 OnExecute(stats, observer);
             }
         }

--- a/test/PollyTick.Tests/BookkeepingObserverTests.cs
+++ b/test/PollyTick.Tests/BookkeepingObserverTests.cs
@@ -18,7 +18,7 @@ namespace PollyTickTests
             {
                 tasks.Add(Task.Run(() =>
                 {
-                    bookkeeper.OnExecute(new Statistics(1, 2, TimeSpan.FromSeconds(3)));
+                    bookkeeper.OnExecute(new Statistics(1, 2, TimeSpan.FromSeconds(3), null));
                 }));
             }
 
@@ -45,8 +45,8 @@ namespace PollyTickTests
         {
             var bookkeeper = new BookkeepingObserver();
 
-            bookkeeper.OnExecute(new Statistics(1, 2, TimeSpan.FromTicks(3)));
-            bookkeeper.OnExecute(new Statistics(4, 5, TimeSpan.FromTicks(6)));
+            bookkeeper.OnExecute(new Statistics(1, 2, TimeSpan.FromTicks(3), null));
+            bookkeeper.OnExecute(new Statistics(4, 5, TimeSpan.FromTicks(6), null));
 
             var stats = bookkeeper.IntoStatistics();
 

--- a/test/PollyTick.Tests/BookkeepingObserverTests.cs
+++ b/test/PollyTick.Tests/BookkeepingObserverTests.cs
@@ -54,5 +54,17 @@ namespace PollyTickTests
             Assert.Equal(7, stats.Exceptions);
             Assert.Equal(9, stats.Elapsed.Ticks);
         }
+
+        [Fact]
+        public void Bookkeeper_WhenExceptionIsCaptured_ExposedInStatistics()
+        {
+            var bookkeeper = new BookkeepingObserver();
+
+            bookkeeper.OnException(new Exception("test"));
+            var stats = bookkeeper.IntoStatistics();
+
+            Assert.Equal("test", bookkeeper.LastException.Message);
+            Assert.Equal("test", stats.FinalException.Message);
+        }
    }
 }

--- a/test/PollyTick.Tests/CompositeObserverTests.cs
+++ b/test/PollyTick.Tests/CompositeObserverTests.cs
@@ -13,7 +13,7 @@ namespace PollyTickTests
             var book2 = new BookkeepingObserver();
             var observer = new CompositeObserver(book1, book2);
                                                  
-            observer.OnExecute(new Statistics(1, 2, TimeSpan.FromSeconds(3)));
+            observer.OnExecute(new Statistics(1, 2, TimeSpan.FromSeconds(3), new Exception("hello")));
 
             Assert.Equal(1, book1.Executions);
             Assert.Equal(1, book2.Executions);

--- a/test/PollyTick.Tests/TickerTests.cs
+++ b/test/PollyTick.Tests/TickerTests.cs
@@ -351,5 +351,16 @@ namespace PollyTickTests
             Assert.IsType<TaskCanceledException>(local.LastException);
             Assert.IsType<TaskCanceledException>(global.LastException);
         }
+
+        [Fact]
+        public async Task Ticker_WhenExceptionIsCaptured_ExposedOnStatistics()
+        {
+            var ticker = Ticker.WithPolicy(Policy.NoOpAsync());
+
+            var stats = await ticker.ExecuteAsync(() => Task.FromException(new Exception("test_exception")));
+
+            Assert.NotNull(stats.FinalException);
+            Assert.Equal("test_exception", stats.FinalException.Message);
+        }
     }
 }


### PR DESCRIPTION
So the exception captured can be observed without having to register a `BookkeepingObserver`.