### PR TITLE
Polly v7 Upgrade

### DIFF
--- a/src/PollyTick/AsyncTickerInstance.Tresult.cs
+++ b/src/PollyTick/AsyncTickerInstance.Tresult.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Polly;
+
+namespace PollyTick
+{
+    public class AsyncTickerInstance<T> : AsyncTickerInstanceBase
+    {
+        private IAsyncPolicy<T> _policy;
+
+        public AsyncTickerInstance(IAsyncPolicy<T> policy)
+        {
+            _policy = policy;
+        }
+        
+        /// <summary>
+        ///   Register a statistics observer. The observer will be called
+        ///   for all executions of this TickerInstance.
+        /// </summary>
+        public AsyncTickerInstance<T> WithObserver(IStatisticsObserver observer)
+        {
+            AddObserver(observer);
+            return this;
+        }
+
+        /// <summary>
+        ///   Execute an awaitable action with instrumentation,
+        ///   returning the statistics and execution result.
+        /// </summary>
+        public Task<Statistics<T>> ExecuteAsync(Func<Task<T>> action)
+        {
+            return ExecuteAsync(action, new NullObserver());
+        }
+
+        /// <summary>
+        ///   Execute an awaitable action with instrumentation,
+        ///   returning the statistics and execution result.
+        /// </summary>
+        public Task<Statistics<T>> ExecuteAsync(
+            Func<CancellationToken, Task<T>> action,
+            CancellationToken token)
+        {
+            return ExecuteAsync(action, new NullObserver(), token);
+        }
+
+        /// <summary>
+        ///   Execute an awaitable action with instrumentation and a statistics
+        ///   observer, returning the execution statistics. The statistics observer
+        ///   will receive a callback with the outcome of the execution.
+        /// </summary>
+        public Task<Statistics<T>> ExecuteAsync(
+            Func<Task<T>> action,
+            IStatisticsObserver observer)
+        {
+            return ExecuteAsync(_ => action(), observer, CancellationToken.None);
+        }
+
+        /// <summary>
+        ///   Execute the Instrumented body without capturing
+        ///   exceptions or intercepting the result.
+        /// </summary>
+        public Task<T> ExecuteNoCaptureAsync(Func<Task<T>> action, IStatisticsObserver observer)
+        {
+            return ExecuteNoCaptureAsync(_ => action(), observer, CancellationToken.None);
+        }
+
+        /// <summary>
+        ///   Execute an awaitable action with instrumentation and a statistics
+        ///   observer, returning the execution statistics. The statistics observer
+        ///   will receive a callback with the outcome of the execution.
+        /// </summary>
+        public async Task<Statistics<T>> ExecuteAsync(
+            Func<CancellationToken, Task<T>> action,
+            IStatisticsObserver observer,
+            CancellationToken token)
+        {
+            var sw = Stopwatch.StartNew();
+            var result = await _policy.ExecuteAndCaptureAsync(action, token);
+            sw.Stop();
+
+            return StatisticsFromResult(result, sw, observer);
+        }
+
+        /// <summary>
+        ///   Execute the Instrumented body without capturing
+        ///   exceptions or intercepting the result.
+        /// </summary>
+        public Task<T> ExecuteNoCaptureAsync(
+            Func<CancellationToken, Task<T>> action,
+            IStatisticsObserver observer,
+            CancellationToken token)
+        {
+            return ExecuteNoCaptureInternalAsync(
+                ct => _policy.ExecuteAsync(action, ct),
+                observer,
+                token);
+        }
+    }
+}

--- a/src/PollyTick/AsyncTickerInstance.cs
+++ b/src/PollyTick/AsyncTickerInstance.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Polly;
+
+namespace PollyTick
+{
+    public class AsyncTickerInstance : AsyncTickerInstanceBase
+    {
+        private IAsyncPolicy _policy;
+
+        public AsyncTickerInstance(IAsyncPolicy policy)
+        {
+            _policy = policy;
+        }
+
+        /// <summary>
+        ///   Register a statistics observer. The observer will be called
+        ///   for all executions of this TickerInstance.
+        /// </summary>
+        public AsyncTickerInstance WithObserver(IStatisticsObserver observer)
+        {
+            AddObserver(observer);
+            return this;
+        }
+
+        /// <summary>
+        ///   Execute an awaitable action with instrumentation,
+        ///   returning the statistics for this execution.
+        /// </summary>
+        public Task<Statistics> ExecuteAsync(Func<Task> action)
+        {
+            return ExecuteAsync(action, new NullObserver());
+        }
+
+        /// <summary>
+        ///   Execute an awaitable action with instrumentation,
+        ///   returning the statistics for this execution.
+        /// </summary>
+        public Task<Statistics> ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken token)
+        {
+            return ExecuteAsync(action, new NullObserver(), token);
+        }
+
+        /// <summary>
+        ///   Execute an awaitable action with instrumentation and a statistics
+        ///   observer, returning the execution statistics. The statistics observer
+        ///   will receive a callback with the outcome of the execution.
+        /// </summary>
+        public Task<Statistics> ExecuteAsync(Func<Task> action, IStatisticsObserver observer)
+        {
+            return ExecuteAsync(_ => action(), observer, CancellationToken.None);
+        }
+
+        /// <summary>
+        ///   Execute the Instrumented body without capturing
+        ///   exceptions or intercepting the result.
+        /// </summary>
+        public Task ExecuteNoCaptureAsync(Func<Task> action, IStatisticsObserver observer)
+        {
+            return ExecuteNoCaptureAsync(_ => action(), observer, CancellationToken.None);
+        }
+
+        /// <summary>
+        ///   Execute an awaitable action with instrumentation and a statistics
+        ///   observer, returning the execution statistics. The statistics observer
+        ///   will receive a callback with the outcome of the execution.
+        /// </summary>
+        public async Task<Statistics> ExecuteAsync(
+            Func<CancellationToken, Task> action,
+            IStatisticsObserver observer,
+            CancellationToken token)
+        {
+            return await ExecuteAsync(async ct => {
+                    await action(ct);
+                    return 0;
+                },
+                observer,
+                token);
+        }
+
+        /// <summary>
+        ///   Execute the Instrumented body without capturing
+        ///   exceptions or intercepting the result.
+        /// </summary>
+        public async Task ExecuteNoCaptureAsync(
+            Func<CancellationToken, Task> action,
+            IStatisticsObserver observer,
+            CancellationToken token)
+        {
+            await ExecuteNoCaptureAsync(async ct => {
+                    await action(ct);
+                    return 0;
+                },
+                observer,
+                token);
+        }
+        
+        /// <summary>
+        ///   Execute an awaitable action with instrumentation,
+        ///   returning the statistics and execution result.
+        /// </summary>
+        public Task<Statistics<T>> ExecuteAsync<T>(Func<Task<T>> action)
+        {
+            return ExecuteAsync(action, new NullObserver());
+        }
+
+        /// <summary>
+        ///   Execute an awaitable action with instrumentation,
+        ///   returning the statistics and execution result.
+        /// </summary>
+        public Task<Statistics<T>> ExecuteAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken token)
+        {
+            return ExecuteAsync(action, new NullObserver(), token);
+        }
+
+        /// <summary>
+        ///   Execute an awaitable action with instrumentation and a statistics
+        ///   observer, returning the execution statistics. The statistics observer
+        ///   will receive a callback with the outcome of the execution.
+        /// </summary>
+        public Task<Statistics<T>> ExecuteAsync<T>(Func<Task<T>> action, IStatisticsObserver observer)
+        {
+            return ExecuteAsync(_ => action(), observer, CancellationToken.None);
+        }
+
+        /// <summary>
+        ///   Execute the Instrumented body without capturing
+        ///   exceptions or intercepting the result.
+        /// </summary>
+        public Task<T> ExecuteNoCaptureAsync<T>(Func<Task<T>> action, IStatisticsObserver observer)
+        {
+            return ExecuteNoCaptureAsync(_ => action(), observer, CancellationToken.None);
+        }
+
+        /// <summary>
+        ///   Execute an awaitable action with instrumentation and a statistics
+        ///   observer, returning the execution statistics. The statistics observer
+        ///   will receive a callback with the outcome of the execution.
+        /// </summary>
+        public async Task<Statistics<T>> ExecuteAsync<T>(
+            Func<CancellationToken, Task<T>> action,
+            IStatisticsObserver observer,
+            CancellationToken token)
+        {
+            var sw = Stopwatch.StartNew();
+            var result = await _policy.ExecuteAndCaptureAsync(action, token);
+            sw.Stop();
+
+            return StatisticsFromResult(result, sw, observer);
+        }
+
+
+        /// <summary>
+        ///   Execute the Instrumented body without capturing
+        ///   exceptions or intercepting the result.
+        /// </summary>
+        public Task<T> ExecuteNoCaptureAsync<T>(
+            Func<CancellationToken, Task<T>> action,
+            IStatisticsObserver observer,
+            CancellationToken token)
+        {
+            return ExecuteNoCaptureInternalAsync(
+                ct => _policy.ExecuteAsync(action, ct),
+                observer,
+                token);
+        }
+    }
+}

--- a/src/PollyTick/AsyncTickerInstanceBase.cs
+++ b/src/PollyTick/AsyncTickerInstanceBase.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace PollyTick
+{
+    public class AsyncTickerInstanceBase : TickerInstanceBase
+    {
+        /// <summary>
+        ///   Internal implementation of the `ExecuteNoCaptureAsync`.
+        /// </summary>
+        protected async Task<T> ExecuteNoCaptureInternalAsync<T>(
+            Func<CancellationToken, Task<T>> action,
+            IStatisticsObserver observer,
+            CancellationToken token)
+        {
+            var sw = Stopwatch.StartNew();
+            var exceptions = 0;
+            T result = default(T);
+			Exception capturedException = null;
+            try
+            {
+                result = await action(token);
+                return result;
+            }
+            catch (Exception e)
+            {
+                OnException(e, observer);
+				capturedException = e;
+                exceptions++;
+                throw;
+            }
+            finally
+            {
+                sw.Stop();
+                var stats = new Statistics<T>(1, exceptions, sw.Elapsed, capturedException, result);
+                OnExecute(stats, observer);
+            }
+        }
+    }
+}

--- a/src/PollyTick/PollyTick.csproj
+++ b/src/PollyTick/PollyTick.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.6.0</VersionPrefix>
     <TargetFramework>netstandard1.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>PollyTick</AssemblyName>
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="polly" Version="6.1.0" />
+    <PackageReference Include="Polly" Version="7.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/PollyTick/SyncTickerInstanceBase.cs
+++ b/src/PollyTick/SyncTickerInstanceBase.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Diagnostics;
+
+namespace PollyTick
+{
+    public class SyncTickerInstanceBase : TickerInstanceBase
+    {
+        /// <summary>
+        ///   Internal implementation of the `ExecuteNoCapture`.
+        /// </summary>
+        protected T ExecuteNoCaptureInternal<T>(Func<T> action, IStatisticsObserver observer)
+        {
+            var sw = Stopwatch.StartNew();
+            int exceptions = 0;
+            T result = default(T);
+			Exception capturedException = null;
+            try
+            {
+                result = action();
+                return result;
+            }
+            catch (Exception e)
+            {
+                OnException(e, observer);
+				capturedException = e;
+                exceptions++;
+                throw;
+            }
+            finally
+            {
+                sw.Stop();
+                var stats = new Statistics<T>(1, exceptions, sw.Elapsed, capturedException, result);
+                OnExecute(stats, observer);
+            }
+        }
+    }
+}

--- a/src/PollyTick/Ticker.cs
+++ b/src/PollyTick/Ticker.cs
@@ -1,17 +1,26 @@
 ﻿using Polly;
+using System.ComponentModel;
 
 namespace PollyTick
 {
     public static class Ticker
     {
-        public static TickerInstance WithPolicy(Policy policy)
+        public static TickerInstance WithPolicy(ISyncPolicy policy)
         {
             return new TickerInstance(policy);
         }
-
-        public static TickerInstance<T> WithPolicy<T>(Policy<T> policy)
+        public static TickerInstance<T> WithPolicy<T>(ISyncPolicy<T> policy)
         {
             return new TickerInstance<T>(policy);
+        }
+
+        public static AsyncTickerInstance WithPolicy(IAsyncPolicy policy)
+        {
+            return new AsyncTickerInstance(policy);
+        }
+        public static AsyncTickerInstance<T> WithPolicy<T>(IAsyncPolicy<T> policy)
+        {
+            return new AsyncTickerInstance<T>(policy);
         }
     }
 }

--- a/src/PollyTick/TickerInstance.TResult.cs
+++ b/src/PollyTick/TickerInstance.TResult.cs
@@ -6,9 +6,11 @@ using System.Threading;
 
 namespace PollyTick
 {
-    public class TickerInstance<T> : TickerInstanceBase
+    public class TickerInstance<T> : SyncTickerInstanceBase
     {
-        public TickerInstance(Policy<T> policy)
+        private ISyncPolicy<T> _policy;
+
+        public TickerInstance(ISyncPolicy<T> policy)
         {
             _policy = policy;
         }
@@ -35,7 +37,7 @@ namespace PollyTick
         /// <summary>
         ///   Execute the instrumented body with a statistics observer,
         ///   returning the execution statistics. The statistics observer
-        ///   will recieve a callback with the outcome of the execution.
+        ///   will receive a callback with the outcome of the execution.
         /// </summary>
         public Statistics<T> Execute(Func<T> action, IStatisticsObserver observer)
         {
@@ -54,80 +56,5 @@ namespace PollyTick
         {
             return ExecuteNoCaptureInternal(() => _policy.Execute(action), observer);
         }
-
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation,
-        ///   returning the statistics and execution result.
-        /// </summary>
-        public Task<Statistics<T>> ExecuteAsync(Func<Task<T>> action)
-        {
-            return ExecuteAsync(action, new NullObserver());
-        }
-
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation,
-        ///   returning the statistics and execution result.
-        /// </summary>
-        public Task<Statistics<T>> ExecuteAsync(
-            Func<CancellationToken, Task<T>> action,
-            CancellationToken token)
-        {
-            return ExecuteAsync(action, new NullObserver(), token);
-        }
-
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation and a statistics
-        ///   observer, returning the execution statistics. The statistics observer
-        ///   will recieve a callback with the outcome of the execution.
-        /// </summary>
-        public Task<Statistics<T>> ExecuteAsync(
-            Func<Task<T>> action,
-            IStatisticsObserver observer)
-        {
-            return ExecuteAsync(_ => action(), observer, CancellationToken.None);
-        }
-
-        /// <summary>
-        ///   Execute the Instrumented body without capturing
-        ///   exceptions or intercepting the result.
-        /// </summary>
-        public Task<T> ExecuteNoCaptureAsync(Func<Task<T>> action, IStatisticsObserver observer)
-        {
-            return ExecuteNoCaptureAsync(_ => action(), observer, CancellationToken.None);
-        }
-
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation and a statistics
-        ///   observer, returning the execution statistics. The statistics observer
-        ///   will recieve a callback with the outcome of the execution.
-        /// </summary>
-        public async Task<Statistics<T>> ExecuteAsync(
-            Func<CancellationToken, Task<T>> action,
-            IStatisticsObserver observer,
-            CancellationToken token)
-        {
-            var sw = Stopwatch.StartNew();
-            var result = await _policy.ExecuteAndCaptureAsync(action, token);
-            sw.Stop();
-
-            return StatisticsFromResult(result, sw, observer);
-        }
-
-        /// <summary>
-        ///   Execute the Instrumented body without capturing
-        ///   exceptions or intercepting the result.
-        /// </summary>
-        public Task<T> ExecuteNoCaptureAsync(
-            Func<CancellationToken, Task<T>> action,
-            IStatisticsObserver observer,
-            CancellationToken token)
-        {
-            return ExecuteNoCaptureInternalAsync(
-                ct => _policy.ExecuteAsync(action, ct),
-                observer,
-                token);
-        }
-
-        private Policy<T> _policy;
     }
 }

--- a/src/PollyTick/TickerInstance.cs
+++ b/src/PollyTick/TickerInstance.cs
@@ -6,9 +6,11 @@ using System.Threading;
 
 namespace PollyTick
 {
-    public class TickerInstance : TickerInstanceBase
+    public class TickerInstance : SyncTickerInstanceBase
     {
-        public TickerInstance(Policy policy)
+        private ISyncPolicy _policy;
+
+        public TickerInstance(ISyncPolicy policy)
         {
             _policy = policy;
         }
@@ -35,7 +37,7 @@ namespace PollyTick
         /// <summary>
         ///   Execute the instrumented body with a statistics observer,
         ///   returning the execution statistics. The statistics observer
-        ///   will recieve a callback with the outcome of the execution.
+        ///   will receive a callback with the outcome of the execution.
         /// </summary>
         public Statistics Execute(Action action, IStatisticsObserver observer)
         {
@@ -63,7 +65,7 @@ namespace PollyTick
         /// <summary>
         ///   Execute the instrumented body with a statistics observer,
         ///   returning the execution statistics. The statistics observer
-        ///   will recieve a callback with the outcome of the execution.
+        ///   will receive a callback with the outcome of the execution.
         /// </summary>
         public Statistics<T> Execute<T>(Func<T> action, IStatisticsObserver observer)
         {
@@ -82,149 +84,5 @@ namespace PollyTick
         {
             return ExecuteNoCaptureInternal(() => _policy.Execute(action), observer);
         }
-
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation,
-        ///   returning the statistics for this execution.
-        /// </summary>
-        public Task<Statistics> ExecuteAsync(Func<Task> action)
-        {
-            return ExecuteAsync(action, new NullObserver());
-        }
-
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation,
-        ///   returning the statistics for this execution.
-        /// </summary>
-        public Task<Statistics> ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken token)
-        {
-            return ExecuteAsync(action, new NullObserver(), token);
-        }
-
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation and a statistics
-        ///   observer, returning the execution statistics. The statistics observer
-        ///   will recieve a callback with the outcome of the execution.
-        /// </summary>
-        public Task<Statistics> ExecuteAsync(Func<Task> action, IStatisticsObserver observer)
-        {
-            return ExecuteAsync(_ => action(), observer, CancellationToken.None);
-        }
-
-        /// <summary>
-        ///   Execute the Instrumented body without capturing
-        ///   exceptions or intercepting the result.
-        /// </summary>
-        public Task ExecuteNoCaptureAsync(Func<Task> action, IStatisticsObserver observer)
-        {
-            return ExecuteNoCaptureAsync(_ => action(), observer, CancellationToken.None);
-        }
-
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation and a statistics
-        ///   observer, returning the execution statistics. The statistics observer
-        ///   will recieve a callback with the outcome of the execution.
-        /// </summary>
-        public async Task<Statistics> ExecuteAsync(
-            Func<CancellationToken, Task> action,
-            IStatisticsObserver observer,
-            CancellationToken token)
-        {
-            return await ExecuteAsync(async ct => {
-                    await action(ct);
-                    return 0;
-                },
-                observer,
-                token);
-        }
-
-        /// <summary>
-        ///   Execute the Instrumented body without capturing
-        ///   exceptions or intercepting the result.
-        /// </summary>
-        public async Task ExecuteNoCaptureAsync(
-            Func<CancellationToken, Task> action,
-            IStatisticsObserver observer,
-            CancellationToken token)
-        {
-            await ExecuteNoCaptureAsync(async ct => {
-                    await action(ct);
-                    return 0;
-                },
-                observer,
-                token);
-        }
-        
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation,
-        ///   returning the statistics and execution result.
-        /// </summary>
-        public Task<Statistics<T>> ExecuteAsync<T>(Func<Task<T>> action)
-        {
-            return ExecuteAsync(action, new NullObserver());
-        }
-
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation,
-        ///   returning the statistics and execution result.
-        /// </summary>
-        public Task<Statistics<T>> ExecuteAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken token)
-        {
-            return ExecuteAsync(action, new NullObserver(), token);
-        }
-
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation and a statistics
-        ///   observer, returning the execution statistics. The statistics observer
-        ///   will recieve a callback with the outcome of the execution.
-        /// </summary>
-        public Task<Statistics<T>> ExecuteAsync<T>(Func<Task<T>> action, IStatisticsObserver observer)
-        {
-            return ExecuteAsync(_ => action(), observer, CancellationToken.None);
-        }
-
-        /// <summary>
-        ///   Execute the Instrumented body without capturing
-        ///   exceptions or intercepting the result.
-        /// </summary>
-        public Task<T> ExecuteNoCaptureAsync<T>(Func<Task<T>> action, IStatisticsObserver observer)
-        {
-            return ExecuteNoCaptureAsync(_ => action(), observer, CancellationToken.None);
-        }
-
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation and a statistics
-        ///   observer, returning the execution statistics. The statistics observer
-        ///   will recieve a callback with the outcome of the execution.
-        /// </summary>
-        public async Task<Statistics<T>> ExecuteAsync<T>(
-            Func<CancellationToken, Task<T>> action,
-            IStatisticsObserver observer,
-            CancellationToken token)
-        {
-            var sw = Stopwatch.StartNew();
-            var result = await _policy.ExecuteAndCaptureAsync(action, token);
-            sw.Stop();
-
-            return StatisticsFromResult(result, sw, observer);
-        }
-
-
-        /// <summary>
-        ///   Execute the Instrumented body without capturing
-        ///   exceptions or intercepting the result.
-        /// </summary>
-        public Task<T> ExecuteNoCaptureAsync<T>(
-            Func<CancellationToken, Task<T>> action,
-            IStatisticsObserver observer,
-            CancellationToken token)
-        {
-            return ExecuteNoCaptureInternalAsync(
-                ct => _policy.ExecuteAsync(action, ct),
-                observer,
-                token);
-        }
-
-        private Policy _policy;
     }
 }

--- a/src/PollyTick/TickerInstanceBase.cs
+++ b/src/PollyTick/TickerInstanceBase.cs
@@ -44,67 +44,6 @@ namespace PollyTick
             return stats;
         }
 
-        /// <summary>
-        ///   Internal implementation of the `ExecuteNoCapture`.
-        /// </summary>
-        protected T ExecuteNoCaptureInternal<T>(Func<T> action, IStatisticsObserver observer)
-        {
-            var sw = Stopwatch.StartNew();
-            int exceptions = 0;
-            T result = default(T);
-			Exception capturedException = null;
-            try
-            {
-                result = action();
-                return result;
-            }
-            catch (Exception e)
-            {
-                OnException(e, observer);
-				capturedException = e;
-                exceptions++;
-                throw;
-            }
-            finally
-            {
-                sw.Stop();
-                var stats = new Statistics<T>(1, exceptions, sw.Elapsed, capturedException, result);
-                OnExecute(stats, observer);
-            }
-        }
-
-        /// <summary>
-        ///   Internal implementation of the `ExecuteNoCaptureAsync`.
-        /// </summary>
-        protected async Task<T> ExecuteNoCaptureInternalAsync<T>(
-            Func<CancellationToken, Task<T>> action,
-            IStatisticsObserver observer,
-            CancellationToken token)
-        {
-            var sw = Stopwatch.StartNew();
-            var exceptions = 0;
-            T result = default(T);
-			Exception capturedException = null;
-            try
-            {
-                result = await action(token);
-                return result;
-            }
-            catch (Exception e)
-            {
-                OnException(e, observer);
-				capturedException = e;
-                exceptions++;
-                throw;
-            }
-            finally
-            {
-                sw.Stop();
-                var stats = new Statistics<T>(1, exceptions, sw.Elapsed, capturedException, result);
-                OnExecute(stats, observer);
-            }
-        }
-
         protected void OnExecute(Statistics stats, IStatisticsObserver observer)
         {
             observer.OnExecute(stats);

--- a/test/PollyTick.Tests/PollyTick.Tests.csproj
+++ b/test/PollyTick.Tests/PollyTick.Tests.csproj
@@ -7,8 +7,8 @@
     <ProjectReference Include="../../src/PollyTick/PollyTick.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Switch to using the IAsyncPolicy and ISyncPolicy interfaces to work
with the latest polly version. This splits out the execution types
into two seeparate classes. You can no longer accidentally use an asyc
policy synchronously and vice versa.