### PR TITLE
Documentation in Package

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 </Project>

--- a/src/PollyTick/AsyncTickerInstance.Tresult.cs
+++ b/src/PollyTick/AsyncTickerInstance.Tresult.cs
@@ -6,11 +6,15 @@ using Polly;
 
 namespace PollyTick
 {
+    /// <summary>
+    ///  A ticker instance which observes an <see cref="IAsyncPolicy{T}" />
+    /// </summary>
+    /// <typeparam name="T">The return type of the policy execution</typeparam>
     public class AsyncTickerInstance<T> : AsyncTickerInstanceBase
     {
         private IAsyncPolicy<T> _policy;
 
-        public AsyncTickerInstance(IAsyncPolicy<T> policy)
+        internal AsyncTickerInstance(IAsyncPolicy<T> policy)
         {
             _policy = policy;
         }

--- a/src/PollyTick/AsyncTickerInstance.cs
+++ b/src/PollyTick/AsyncTickerInstance.cs
@@ -6,11 +6,14 @@ using Polly;
 
 namespace PollyTick
 {
+    /// <summary>
+    ///  A ticker instance which observes an <see cref="IAsyncPolicy" />
+    /// </summary>
     public class AsyncTickerInstance : AsyncTickerInstanceBase
     {
         private IAsyncPolicy _policy;
 
-        public AsyncTickerInstance(IAsyncPolicy policy)
+        internal AsyncTickerInstance(IAsyncPolicy policy)
         {
             _policy = policy;
         }

--- a/src/PollyTick/AsyncTickerInstanceBase.cs
+++ b/src/PollyTick/AsyncTickerInstanceBase.cs
@@ -5,6 +5,9 @@ using System.Threading.Tasks;
 
 namespace PollyTick
 {
+    /// <summary>
+    /// Base class for all async ticker instances
+    /// </summary>
     public class AsyncTickerInstanceBase : TickerInstanceBase
     {
         /// <summary>

--- a/src/PollyTick/BookKeepingObserver.cs
+++ b/src/PollyTick/BookKeepingObserver.cs
@@ -10,6 +10,35 @@ namespace PollyTick
     /// </summary>
     public class BookkeepingObserver : IStatisticsObserver
     {
+        private int _executions;
+        private int _exceptions;
+        private long _totalTimespanTicks;
+
+        /// <summary>
+        ///   The number of Executions observed by this instance overall.
+        /// </summary>
+        public int Executions => _executions;
+
+        /// <summary>
+        ///   The number of Exceptions observed by this instance overall.
+        /// </summary>
+        public int Exceptions => _exceptions;
+
+        /// <summary>
+        ///   The total execution time observed by this instance
+        ///   overall, as a <see cref="TimeSpan" />.
+        /// </summary>
+        public TimeSpan Elapsed => TimeSpan.FromTicks(Interlocked.Read(ref _totalTimespanTicks));
+
+        /// <summary>
+        ///   The last exception observed by this listener.
+        /// </summary>
+        public Exception LastException { get; private set; }
+
+        /// <summary>
+        ///  Called by a ticker ticker instance when an execution completes
+        /// </summary>
+        /// <param name="statistics">The statistics for the given execution</param>
         public void OnExecute(Statistics statistics)
         {
             Interlocked.Add(ref _executions, statistics.Executions);
@@ -17,6 +46,10 @@ namespace PollyTick
             Interlocked.Add(ref _totalTimespanTicks, statistics.Elapsed.Ticks);
         }
 
+        /// <summary>
+        ///  Called by a ticker instance when an exception is caught
+        /// </summary>
+        /// <param name="exception">The exception that was observed</param>
         public void OnException(Exception exception)
         {
             LastException = exception;
@@ -33,29 +66,5 @@ namespace PollyTick
             long ticks = Interlocked.Read(ref _totalTimespanTicks);
             return new Statistics(executions, exceptions, TimeSpan.FromTicks(ticks), LastException);
         }
-
-        /// <summary>
-        ///   The number of Executions observed by this instance overall.
-        /// </summary>
-        public int Executions => _executions;
-        private int _executions;
-
-        /// <summary>
-        ///   The number of Exceptions observed by this instance overall.
-        /// </summary>
-        public int Exceptions => _exceptions;
-        private int _exceptions;
-
-        /// <summary>
-        ///   The total execution time observed by this instance
-        ///   overall, as a <see cref="TimeSpan" />.
-        /// </summary>
-        public TimeSpan Elapsed => TimeSpan.FromTicks(Interlocked.Read(ref _totalTimespanTicks));
-        private long _totalTimespanTicks;
-
-        /// <summary>
-        ///   The last exception observed by this listener.
-        /// </summary>
-        public Exception LastException;
     }
 }

--- a/src/PollyTick/CompositeObserver.cs
+++ b/src/PollyTick/CompositeObserver.cs
@@ -2,25 +2,42 @@ using System;
 
 namespace PollyTick
 {
+    /// <summary>
+    ///  A statistics observer that forwards on to a collection
+    ///  of inner observers.
+    /// </summary>
     public class CompositeObserver : IStatisticsObserver
     {
         private IStatisticsObserver[] _observers;
 
+        /// <summary>
+        ///  Create a new observer that wraps the given set of
+        ///  <paramref name="observers" />.
+        /// </summary>
+        /// <param name="observers">The observers to wrap</param>
         public CompositeObserver(params IStatisticsObserver[] observers)
         {
             _observers = observers;
         }
 
-        public void OnException(Exception exception)
-        {
-            foreach (var obs in _observers)
-                obs.OnException(exception);
-        }
-
+        /// <summary>
+        ///  Called by a ticker ticker instance when an execution completes
+        /// </summary>
+        /// <param name="statistics">The statistics for the given execution</param>
         public void OnExecute(Statistics statistics)
         {
             foreach (var obs in _observers)
                 obs.OnExecute(statistics);
+        }
+
+        /// <summary>
+        ///  Called by a ticker instance when an exception is caught
+        /// </summary>
+        /// <param name="exception">The exception observed</param>
+        public void OnException(Exception exception)
+        {
+            foreach (var obs in _observers)
+                obs.OnException(exception);
         }
     }
 }

--- a/src/PollyTick/IStatisticsObserver.cs
+++ b/src/PollyTick/IStatisticsObserver.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace PollyTick
 {
+    /// <summary>
+    ///   An observer of <see cref="TickerInstance" /> executions.
+    /// </summary>
     public interface IStatisticsObserver
     {
         /// <summary>

--- a/src/PollyTick/NullObserver.cs
+++ b/src/PollyTick/NullObserver.cs
@@ -8,10 +8,18 @@ namespace PollyTick
     /// </statistics>
     public class NullObserver : IStatisticsObserver
     {
+        /// <summary>
+        /// Does nothing when the statistics from an execution
+        /// </summary>
+        /// <param name="statistics">The statistics to ignore</param>
         public void OnExecute(Statistics statistics)
         {
         }
 
+        /// <summary>
+        ///  Does nothing with an exception observed during execution.
+        /// </summary>
+        /// <param name="exception">The exception to ignore</param>
         public void OnException(Exception exception)
         {
         }

--- a/src/PollyTick/Statistics.cs
+++ b/src/PollyTick/Statistics.cs
@@ -9,6 +9,13 @@ namespace PollyTick
     /// </summary>
     public class Statistics
     {
+        /// <summary>
+        ///  Create a new statistics instance
+        /// </summary>
+        /// <param name="executions">The number of excecutions this statistics object covers</param>
+        /// <param name="exceptions">The number of exceptions observed</param>
+        /// <param name="elapsed">The total elapsed time observed</param>
+        /// <param name="finalException">The last exception observed, if any</param>
         public Statistics(int executions, int exceptions, TimeSpan elapsed, Exception finalException)
         {
             Executions = executions;
@@ -45,6 +52,14 @@ namespace PollyTick
     /// </summary>
     public class Statistics<T> : Statistics
     {
+        /// <summary>
+        ///  Create a new statistics instance, with a result value.
+        /// </summary>
+        /// <param name="executions">The number of excecutions this statistics object covers</param>
+        /// <param name="exceptions">The number of exceptions observed</param>
+        /// <param name="elapsed">The total elapsed time observed</param>
+        /// <param name="finalException">The last exception observed, if any</param>
+        /// <param name="result">The result of the execution</param>
         public Statistics(int executions, int exceptions, TimeSpan elapsed, Exception finalException, T result)
             : base(executions, exceptions, elapsed, finalException)
         {

--- a/src/PollyTick/SyncTickerInstanceBase.cs
+++ b/src/PollyTick/SyncTickerInstanceBase.cs
@@ -3,6 +3,9 @@ using System.Diagnostics;
 
 namespace PollyTick
 {
+    /// <summary>
+    ///   Base class for all synchronous ticker instances
+    /// </summary>
     public class SyncTickerInstanceBase : TickerInstanceBase
     {
         /// <summary>

--- a/src/PollyTick/Ticker.cs
+++ b/src/PollyTick/Ticker.cs
@@ -3,21 +3,52 @@ using System.ComponentModel;
 
 namespace PollyTick
 {
+    /// <summary>
+    ///  Factory methods for creating ticker instances
+    /// </summary>
     public static class Ticker
     {
+        /// <summary>
+        ///   Create a ticker instance wrapping a synchronous policy
+        ///   with no return value.
+        /// </summary>
+        /// <param name="policy">The policy to wrap</param>
+        /// <returns>A ticker instance to observe policy excecutions</returns>
         public static TickerInstance WithPolicy(ISyncPolicy policy)
         {
             return new TickerInstance(policy);
         }
+
+        /// <summary>
+        ///   Create a ticker instance wrapping a synchronous policy
+        ///   which returns <typeparamref name="T" />.
+        /// </summary>
+        /// <param name="policy">The policy to wrap</param>
+        /// <typeparam name="T">The return type of the policy execution</typeparam>
+        /// <returns>A ticker instance to observe policy excecutions</returns>
         public static TickerInstance<T> WithPolicy<T>(ISyncPolicy<T> policy)
         {
             return new TickerInstance<T>(policy);
         }
 
+        /// <summary>
+        ///   Create a ticker instance wrapping an asynchronous policy
+        ///   with no return value.
+        /// </summary>
+        /// <param name="policy">The policy to wrap</param>
+        /// <returns>A ticker instance to observe policy excecutions</returns>
         public static AsyncTickerInstance WithPolicy(IAsyncPolicy policy)
         {
             return new AsyncTickerInstance(policy);
         }
+
+        /// <summary>
+        ///   Create a ticker instance wrapping an asynchronous policy
+        ///   which returns <typeparamref name="T" />.
+        /// </summary>
+        /// <param name="policy">The policy to wrap</param>
+        /// <typeparam name="T">The return type of the policy execution</typeparam>
+        /// <returns>A ticker instance to observe policy excecutions</returns>
         public static AsyncTickerInstance<T> WithPolicy<T>(IAsyncPolicy<T> policy)
         {
             return new AsyncTickerInstance<T>(policy);

--- a/src/PollyTick/TickerInstance.TResult.cs
+++ b/src/PollyTick/TickerInstance.TResult.cs
@@ -6,11 +6,14 @@ using System.Threading;
 
 namespace PollyTick
 {
+    /// <summary>
+    ///  A ticker instance which observes an <see cref="ISyncPolicy{T}" />.
+    /// </summary>
     public class TickerInstance<T> : SyncTickerInstanceBase
     {
         private ISyncPolicy<T> _policy;
 
-        public TickerInstance(ISyncPolicy<T> policy)
+        internal TickerInstance(ISyncPolicy<T> policy)
         {
             _policy = policy;
         }

--- a/src/PollyTick/TickerInstance.cs
+++ b/src/PollyTick/TickerInstance.cs
@@ -6,11 +6,14 @@ using System.Threading;
 
 namespace PollyTick
 {
+    /// <summary>
+    ///  A ticker instance which observes an <see cref="ISyncPolicy" />.
+    /// </summary>
     public class TickerInstance : SyncTickerInstanceBase
     {
         private ISyncPolicy _policy;
 
-        public TickerInstance(ISyncPolicy policy)
+        internal TickerInstance(ISyncPolicy policy)
         {
             _policy = policy;
         }

--- a/src/PollyTick/TickerInstanceBase.cs
+++ b/src/PollyTick/TickerInstanceBase.cs
@@ -7,8 +7,16 @@ using Polly;
 
 namespace PollyTick
 {
+    /// <summary>
+    ///  The base class for all ticker instances
+    /// </summary>
     public abstract class TickerInstanceBase
     {
+        private List<IStatisticsObserver> _observers;
+        
+        /// <summary>
+        ///  Create an instance of a ticker instance
+        /// </summary>
         protected TickerInstanceBase()
         {
             _observers = new List<IStatisticsObserver>(3);
@@ -44,6 +52,11 @@ namespace PollyTick
             return stats;
         }
 
+        /// <summary>
+        /// Notify observers of the result of an excecution
+        /// </summary>
+        /// <param name="stats">The statistics for the execution</param>
+        /// <param name="observer">An immediate observer to also notify</param>
         protected void OnExecute(Statistics stats, IStatisticsObserver observer)
         {
             observer.OnExecute(stats);
@@ -53,6 +66,11 @@ namespace PollyTick
             }
         }
 
+        /// <summary>
+        /// Notify observers of an exception
+        /// </summary>
+        /// <param name="exception">The exceptions observed</param>
+        /// <param name="observer">An immediate observer to also notify</param>
         protected void OnException(Exception exception, IStatisticsObserver observer)
         {
             observer.OnException(exception);
@@ -61,7 +79,5 @@ namespace PollyTick
                 obs.OnException(exception);
             }
         }
-
-        private List<IStatisticsObserver> _observers;
     }
 }


### PR DESCRIPTION
Fixes #14 by adding `<GenerateDocumentationFile>true</GenerateDocumentationFile>` to
the project. Still TODO:

 * [x] Document each undocumented item
 * [x] Deny the CS1591 warning to prevent undocumented items being included later.