### PR TITLE
Remove Stopwatch Allocations

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-format": {
+      "version": "5.1.250801",
+      "commands": [
+        "dotnet-format"
+      ]
+    }
+  }
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+    <PropertyGroup>
+        <LangVersion>Latest</LangVersion>
+    </PropertyGroup>
+</Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,14 @@
 version: 0.0.{build}-pre
-image: Visual Studio 2019
+image: Visual Studio 2022 
 install:
   - ps: dotnet --version
+  - ps: dotnet tool restore
   - ps: dotnet restore
 build_script:
   - ps: dotnet build Polly.Tick.sln
   - ps: dotnet pack --configuration Release
 test_script:
+  - ps: dotnet tool run dotnet-format -- --check
   - ps: ForEach ($proj in (Get-ChildItem -Path test -Recurse -Filter '*.csproj')) { dotnet test $proj.FullName }
 artifacts:
   - path: '**/*.nupkg'

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
+    <Import Project="../Directory.Build.props" />
     <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <LangVersion>Latest</LangVersion>
         <Nullable>enable</Nullable>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     </PropertyGroup>

--- a/src/PollyTick/AsyncTickerInstance.Tresult.cs
+++ b/src/PollyTick/AsyncTickerInstance.Tresult.cs
@@ -80,11 +80,11 @@ namespace PollyTick
             IStatisticsObserver observer,
             CancellationToken token)
         {
-            var sw = Stopwatch.StartNew();
+            var start = Stopwatch.GetTimestamp();
             var result = await _policy.ExecuteAndCaptureAsync(action, token);
-            sw.Stop();
+            var end = Stopwatch.GetTimestamp();
 
-            return StatisticsFromResult(result, sw, observer);
+            return StatisticsFromResult(result, TimeSpanFromTicks(end - start), observer);
         }
 
         /// <summary>

--- a/src/PollyTick/AsyncTickerInstance.Tresult.cs
+++ b/src/PollyTick/AsyncTickerInstance.Tresult.cs
@@ -4,102 +4,101 @@ using System.Threading;
 using System.Threading.Tasks;
 using Polly;
 
-namespace PollyTick
+namespace PollyTick;
+
+/// <summary>
+///  A ticker instance which observes an <see cref="IAsyncPolicy{T}" />
+/// </summary>
+/// <typeparam name="T">The return type of the policy execution</typeparam>
+public class AsyncTickerInstance<T> : AsyncTickerInstanceBase
 {
-    /// <summary>
-    ///  A ticker instance which observes an <see cref="IAsyncPolicy{T}" />
-    /// </summary>
-    /// <typeparam name="T">The return type of the policy execution</typeparam>
-    public class AsyncTickerInstance<T> : AsyncTickerInstanceBase
+    private IAsyncPolicy<T> _policy;
+
+    internal AsyncTickerInstance(IAsyncPolicy<T> policy)
     {
-        private IAsyncPolicy<T> _policy;
+        _policy = policy;
+    }
 
-        internal AsyncTickerInstance(IAsyncPolicy<T> policy)
-        {
-            _policy = policy;
-        }
-        
-        /// <summary>
-        ///   Register a statistics observer. The observer will be called
-        ///   for all executions of this TickerInstance.
-        /// </summary>
-        public AsyncTickerInstance<T> WithObserver(IStatisticsObserver observer)
-        {
-            AddObserver(observer);
-            return this;
-        }
+    /// <summary>
+    ///   Register a statistics observer. The observer will be called
+    ///   for all executions of this TickerInstance.
+    /// </summary>
+    public AsyncTickerInstance<T> WithObserver(IStatisticsObserver observer)
+    {
+        AddObserver(observer);
+        return this;
+    }
 
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation,
-        ///   returning the statistics and execution result.
-        /// </summary>
-        public Task<Statistics<T>> ExecuteAsync(Func<Task<T>> action)
-        {
-            return ExecuteAsync(action, new NullObserver());
-        }
+    /// <summary>
+    ///   Execute an awaitable action with instrumentation,
+    ///   returning the statistics and execution result.
+    /// </summary>
+    public Task<Statistics<T>> ExecuteAsync(Func<Task<T>> action)
+    {
+        return ExecuteAsync(action, new NullObserver());
+    }
 
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation,
-        ///   returning the statistics and execution result.
-        /// </summary>
-        public Task<Statistics<T>> ExecuteAsync(
-            Func<CancellationToken, Task<T>> action,
-            CancellationToken token)
-        {
-            return ExecuteAsync(action, new NullObserver(), token);
-        }
+    /// <summary>
+    ///   Execute an awaitable action with instrumentation,
+    ///   returning the statistics and execution result.
+    /// </summary>
+    public Task<Statistics<T>> ExecuteAsync(
+        Func<CancellationToken, Task<T>> action,
+        CancellationToken token)
+    {
+        return ExecuteAsync(action, new NullObserver(), token);
+    }
 
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation and a statistics
-        ///   observer, returning the execution statistics. The statistics observer
-        ///   will receive a callback with the outcome of the execution.
-        /// </summary>
-        public Task<Statistics<T>> ExecuteAsync(
-            Func<Task<T>> action,
-            IStatisticsObserver observer)
-        {
-            return ExecuteAsync(_ => action(), observer, CancellationToken.None);
-        }
+    /// <summary>
+    ///   Execute an awaitable action with instrumentation and a statistics
+    ///   observer, returning the execution statistics. The statistics observer
+    ///   will receive a callback with the outcome of the execution.
+    /// </summary>
+    public Task<Statistics<T>> ExecuteAsync(
+        Func<Task<T>> action,
+        IStatisticsObserver observer)
+    {
+        return ExecuteAsync(_ => action(), observer, CancellationToken.None);
+    }
 
-        /// <summary>
-        ///   Execute the Instrumented body without capturing
-        ///   exceptions or intercepting the result.
-        /// </summary>
-        public Task<T> ExecuteNoCaptureAsync(Func<Task<T>> action, IStatisticsObserver observer)
-        {
-            return ExecuteNoCaptureAsync(_ => action(), observer, CancellationToken.None);
-        }
+    /// <summary>
+    ///   Execute the Instrumented body without capturing
+    ///   exceptions or intercepting the result.
+    /// </summary>
+    public Task<T> ExecuteNoCaptureAsync(Func<Task<T>> action, IStatisticsObserver observer)
+    {
+        return ExecuteNoCaptureAsync(_ => action(), observer, CancellationToken.None);
+    }
 
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation and a statistics
-        ///   observer, returning the execution statistics. The statistics observer
-        ///   will receive a callback with the outcome of the execution.
-        /// </summary>
-        public async Task<Statistics<T>> ExecuteAsync(
-            Func<CancellationToken, Task<T>> action,
-            IStatisticsObserver observer,
-            CancellationToken token)
-        {
-            var start = Stopwatch.GetTimestamp();
-            var result = await _policy.ExecuteAndCaptureAsync(action, token);
-            var end = Stopwatch.GetTimestamp();
+    /// <summary>
+    ///   Execute an awaitable action with instrumentation and a statistics
+    ///   observer, returning the execution statistics. The statistics observer
+    ///   will receive a callback with the outcome of the execution.
+    /// </summary>
+    public async Task<Statistics<T>> ExecuteAsync(
+        Func<CancellationToken, Task<T>> action,
+        IStatisticsObserver observer,
+        CancellationToken token)
+    {
+        var start = Stopwatch.GetTimestamp();
+        var result = await _policy.ExecuteAndCaptureAsync(action, token);
+        var end = Stopwatch.GetTimestamp();
 
-            return StatisticsFromResult(result, TimeSpanFromTicks(end - start), observer);
-        }
+        return StatisticsFromResult(result, TimeSpanFromTicks(end - start), observer);
+    }
 
-        /// <summary>
-        ///   Execute the Instrumented body without capturing
-        ///   exceptions or intercepting the result.
-        /// </summary>
-        public Task<T> ExecuteNoCaptureAsync(
-            Func<CancellationToken, Task<T>> action,
-            IStatisticsObserver observer,
-            CancellationToken token)
-        {
-            return ExecuteNoCaptureInternalAsync(
-                ct => _policy.ExecuteAsync(action, ct),
-                observer,
-                token);
-        }
+    /// <summary>
+    ///   Execute the Instrumented body without capturing
+    ///   exceptions or intercepting the result.
+    /// </summary>
+    public Task<T> ExecuteNoCaptureAsync(
+        Func<CancellationToken, Task<T>> action,
+        IStatisticsObserver observer,
+        CancellationToken token)
+    {
+        return ExecuteNoCaptureInternalAsync(
+            ct => _policy.ExecuteAsync(action, ct),
+            observer,
+            token);
     }
 }

--- a/src/PollyTick/AsyncTickerInstance.cs
+++ b/src/PollyTick/AsyncTickerInstance.cs
@@ -87,12 +87,12 @@ namespace PollyTick
         ///   Execute the Instrumented body without capturing
         ///   exceptions or intercepting the result.
         /// </summary>
-        public async Task ExecuteNoCaptureAsync(
+        public Task ExecuteNoCaptureAsync(
             Func<CancellationToken, Task> action,
             IStatisticsObserver observer,
             CancellationToken token)
         {
-            await ExecuteNoCaptureAsync(async ct => {
+            return ExecuteNoCaptureAsync(async ct => {
                     await action(ct);
                     return 0;
                 },
@@ -147,11 +147,11 @@ namespace PollyTick
             IStatisticsObserver observer,
             CancellationToken token)
         {
-            var sw = Stopwatch.StartNew();
+            var start = Stopwatch.GetTimestamp();
             var result = await _policy.ExecuteAndCaptureAsync(action, token);
-            sw.Stop();
+            var end = Stopwatch.GetTimestamp();
 
-            return StatisticsFromResult(result, sw, observer);
+            return StatisticsFromResult(result, TimeSpanFromTicks(end - start), observer);
         }
 
 

--- a/src/PollyTick/AsyncTickerInstance.cs
+++ b/src/PollyTick/AsyncTickerInstance.cs
@@ -4,170 +4,171 @@ using System.Threading;
 using System.Threading.Tasks;
 using Polly;
 
-namespace PollyTick
+namespace PollyTick;
+
+/// <summary>
+///  A ticker instance which observes an <see cref="IAsyncPolicy" />
+/// </summary>
+public class AsyncTickerInstance : AsyncTickerInstanceBase
 {
-    /// <summary>
-    ///  A ticker instance which observes an <see cref="IAsyncPolicy" />
-    /// </summary>
-    public class AsyncTickerInstance : AsyncTickerInstanceBase
+    private IAsyncPolicy _policy;
+
+    internal AsyncTickerInstance(IAsyncPolicy policy)
     {
-        private IAsyncPolicy _policy;
+        _policy = policy;
+    }
 
-        internal AsyncTickerInstance(IAsyncPolicy policy)
+    /// <summary>
+    ///   Register a statistics observer. The observer will be called
+    ///   for all executions of this TickerInstance.
+    /// </summary>
+    public AsyncTickerInstance WithObserver(IStatisticsObserver observer)
+    {
+        AddObserver(observer);
+        return this;
+    }
+
+    /// <summary>
+    ///   Execute an awaitable action with instrumentation,
+    ///   returning the statistics for this execution.
+    /// </summary>
+    public Task<Statistics> ExecuteAsync(Func<Task> action)
+    {
+        return ExecuteAsync(action, new NullObserver());
+    }
+
+    /// <summary>
+    ///   Execute an awaitable action with instrumentation,
+    ///   returning the statistics for this execution.
+    /// </summary>
+    public Task<Statistics> ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken token)
+    {
+        return ExecuteAsync(action, new NullObserver(), token);
+    }
+
+    /// <summary>
+    ///   Execute an awaitable action with instrumentation and a statistics
+    ///   observer, returning the execution statistics. The statistics observer
+    ///   will receive a callback with the outcome of the execution.
+    /// </summary>
+    public Task<Statistics> ExecuteAsync(Func<Task> action, IStatisticsObserver observer)
+    {
+        return ExecuteAsync(_ => action(), observer, CancellationToken.None);
+    }
+
+    /// <summary>
+    ///   Execute the Instrumented body without capturing
+    ///   exceptions or intercepting the result.
+    /// </summary>
+    public Task ExecuteNoCaptureAsync(Func<Task> action, IStatisticsObserver observer)
+    {
+        return ExecuteNoCaptureAsync(_ => action(), observer, CancellationToken.None);
+    }
+
+    /// <summary>
+    ///   Execute an awaitable action with instrumentation and a statistics
+    ///   observer, returning the execution statistics. The statistics observer
+    ///   will receive a callback with the outcome of the execution.
+    /// </summary>
+    public async Task<Statistics> ExecuteAsync(
+        Func<CancellationToken, Task> action,
+        IStatisticsObserver observer,
+        CancellationToken token)
+    {
+        return await ExecuteAsync(async ct =>
         {
-            _policy = policy;
-        }
+            await action(ct);
+            return 0;
+        },
+            observer,
+            token);
+    }
 
-        /// <summary>
-        ///   Register a statistics observer. The observer will be called
-        ///   for all executions of this TickerInstance.
-        /// </summary>
-        public AsyncTickerInstance WithObserver(IStatisticsObserver observer)
+    /// <summary>
+    ///   Execute the Instrumented body without capturing
+    ///   exceptions or intercepting the result.
+    /// </summary>
+    public Task ExecuteNoCaptureAsync(
+        Func<CancellationToken, Task> action,
+        IStatisticsObserver observer,
+        CancellationToken token)
+    {
+        return ExecuteNoCaptureAsync(async ct =>
         {
-            AddObserver(observer);
-            return this;
-        }
+            await action(ct);
+            return 0;
+        },
+            observer,
+            token);
+    }
 
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation,
-        ///   returning the statistics for this execution.
-        /// </summary>
-        public Task<Statistics> ExecuteAsync(Func<Task> action)
-        {
-            return ExecuteAsync(action, new NullObserver());
-        }
+    /// <summary>
+    ///   Execute an awaitable action with instrumentation,
+    ///   returning the statistics and execution result.
+    /// </summary>
+    public Task<Statistics<T>> ExecuteAsync<T>(Func<Task<T>> action)
+    {
+        return ExecuteAsync(action, new NullObserver());
+    }
 
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation,
-        ///   returning the statistics for this execution.
-        /// </summary>
-        public Task<Statistics> ExecuteAsync(Func<CancellationToken, Task> action, CancellationToken token)
-        {
-            return ExecuteAsync(action, new NullObserver(), token);
-        }
+    /// <summary>
+    ///   Execute an awaitable action with instrumentation,
+    ///   returning the statistics and execution result.
+    /// </summary>
+    public Task<Statistics<T>> ExecuteAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken token)
+    {
+        return ExecuteAsync(action, new NullObserver(), token);
+    }
 
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation and a statistics
-        ///   observer, returning the execution statistics. The statistics observer
-        ///   will receive a callback with the outcome of the execution.
-        /// </summary>
-        public Task<Statistics> ExecuteAsync(Func<Task> action, IStatisticsObserver observer)
-        {
-            return ExecuteAsync(_ => action(), observer, CancellationToken.None);
-        }
+    /// <summary>
+    ///   Execute an awaitable action with instrumentation and a statistics
+    ///   observer, returning the execution statistics. The statistics observer
+    ///   will receive a callback with the outcome of the execution.
+    /// </summary>
+    public Task<Statistics<T>> ExecuteAsync<T>(Func<Task<T>> action, IStatisticsObserver observer)
+    {
+        return ExecuteAsync(_ => action(), observer, CancellationToken.None);
+    }
 
-        /// <summary>
-        ///   Execute the Instrumented body without capturing
-        ///   exceptions or intercepting the result.
-        /// </summary>
-        public Task ExecuteNoCaptureAsync(Func<Task> action, IStatisticsObserver observer)
-        {
-            return ExecuteNoCaptureAsync(_ => action(), observer, CancellationToken.None);
-        }
+    /// <summary>
+    ///   Execute the Instrumented body without capturing
+    ///   exceptions or intercepting the result.
+    /// </summary>
+    public Task<T> ExecuteNoCaptureAsync<T>(Func<Task<T>> action, IStatisticsObserver observer)
+    {
+        return ExecuteNoCaptureAsync(_ => action(), observer, CancellationToken.None);
+    }
 
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation and a statistics
-        ///   observer, returning the execution statistics. The statistics observer
-        ///   will receive a callback with the outcome of the execution.
-        /// </summary>
-        public async Task<Statistics> ExecuteAsync(
-            Func<CancellationToken, Task> action,
-            IStatisticsObserver observer,
-            CancellationToken token)
-        {
-            return await ExecuteAsync(async ct => {
-                    await action(ct);
-                    return 0;
-                },
-                observer,
-                token);
-        }
+    /// <summary>
+    ///   Execute an awaitable action with instrumentation and a statistics
+    ///   observer, returning the execution statistics. The statistics observer
+    ///   will receive a callback with the outcome of the execution.
+    /// </summary>
+    public async Task<Statistics<T>> ExecuteAsync<T>(
+        Func<CancellationToken, Task<T>> action,
+        IStatisticsObserver observer,
+        CancellationToken token)
+    {
+        var start = Stopwatch.GetTimestamp();
+        var result = await _policy.ExecuteAndCaptureAsync(action, token);
+        var end = Stopwatch.GetTimestamp();
 
-        /// <summary>
-        ///   Execute the Instrumented body without capturing
-        ///   exceptions or intercepting the result.
-        /// </summary>
-        public Task ExecuteNoCaptureAsync(
-            Func<CancellationToken, Task> action,
-            IStatisticsObserver observer,
-            CancellationToken token)
-        {
-            return ExecuteNoCaptureAsync(async ct => {
-                    await action(ct);
-                    return 0;
-                },
-                observer,
-                token);
-        }
-        
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation,
-        ///   returning the statistics and execution result.
-        /// </summary>
-        public Task<Statistics<T>> ExecuteAsync<T>(Func<Task<T>> action)
-        {
-            return ExecuteAsync(action, new NullObserver());
-        }
-
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation,
-        ///   returning the statistics and execution result.
-        /// </summary>
-        public Task<Statistics<T>> ExecuteAsync<T>(Func<CancellationToken, Task<T>> action, CancellationToken token)
-        {
-            return ExecuteAsync(action, new NullObserver(), token);
-        }
-
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation and a statistics
-        ///   observer, returning the execution statistics. The statistics observer
-        ///   will receive a callback with the outcome of the execution.
-        /// </summary>
-        public Task<Statistics<T>> ExecuteAsync<T>(Func<Task<T>> action, IStatisticsObserver observer)
-        {
-            return ExecuteAsync(_ => action(), observer, CancellationToken.None);
-        }
-
-        /// <summary>
-        ///   Execute the Instrumented body without capturing
-        ///   exceptions or intercepting the result.
-        /// </summary>
-        public Task<T> ExecuteNoCaptureAsync<T>(Func<Task<T>> action, IStatisticsObserver observer)
-        {
-            return ExecuteNoCaptureAsync(_ => action(), observer, CancellationToken.None);
-        }
-
-        /// <summary>
-        ///   Execute an awaitable action with instrumentation and a statistics
-        ///   observer, returning the execution statistics. The statistics observer
-        ///   will receive a callback with the outcome of the execution.
-        /// </summary>
-        public async Task<Statistics<T>> ExecuteAsync<T>(
-            Func<CancellationToken, Task<T>> action,
-            IStatisticsObserver observer,
-            CancellationToken token)
-        {
-            var start = Stopwatch.GetTimestamp();
-            var result = await _policy.ExecuteAndCaptureAsync(action, token);
-            var end = Stopwatch.GetTimestamp();
-
-            return StatisticsFromResult(result, TimeSpanFromTicks(end - start), observer);
-        }
+        return StatisticsFromResult(result, TimeSpanFromTicks(end - start), observer);
+    }
 
 
-        /// <summary>
-        ///   Execute the Instrumented body without capturing
-        ///   exceptions or intercepting the result.
-        /// </summary>
-        public Task<T> ExecuteNoCaptureAsync<T>(
-            Func<CancellationToken, Task<T>> action,
-            IStatisticsObserver observer,
-            CancellationToken token)
-        {
-            return ExecuteNoCaptureInternalAsync(
-                ct => _policy.ExecuteAsync(action, ct),
-                observer,
-                token);
-        }
+    /// <summary>
+    ///   Execute the Instrumented body without capturing
+    ///   exceptions or intercepting the result.
+    /// </summary>
+    public Task<T> ExecuteNoCaptureAsync<T>(
+        Func<CancellationToken, Task<T>> action,
+        IStatisticsObserver observer,
+        CancellationToken token)
+    {
+        return ExecuteNoCaptureInternalAsync(
+            ct => _policy.ExecuteAsync(action, ct),
+            observer,
+            token);
     }
 }

--- a/src/PollyTick/AsyncTickerInstanceBase.cs
+++ b/src/PollyTick/AsyncTickerInstanceBase.cs
@@ -18,17 +18,20 @@ public class AsyncTickerInstanceBase : TickerInstanceBase
         IStatisticsObserver observer,
         CancellationToken token)
     {
-        var sw = Stopwatch.StartNew();
+        var start = Stopwatch.GetTimestamp();
+        var end = start;
         var exceptions = 0;
         T? result = default;
         Exception? capturedException = null;
         try
         {
             result = await action(token);
+            end = Stopwatch.GetTimestamp();
             return result;
         }
         catch (Exception e)
         {
+            end = Stopwatch.GetTimestamp();
             OnException(e, observer);
             capturedException = e;
             exceptions++;
@@ -36,8 +39,7 @@ public class AsyncTickerInstanceBase : TickerInstanceBase
         }
         finally
         {
-            sw.Stop();
-            var stats = new Statistics<T>(1, exceptions, sw.Elapsed, capturedException, result);
+            var stats = new Statistics<T>(1, exceptions, TimeSpanFromTicks(end - start), capturedException, result);
             OnExecute(stats, observer);
         }
     }

--- a/src/PollyTick/BookKeepingObserver.cs
+++ b/src/PollyTick/BookKeepingObserver.cs
@@ -2,69 +2,68 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 
-namespace PollyTick
+namespace PollyTick;
+
+/// <summary>
+///   An IStatisticsObserver which collcts each event
+///   internally for later observation.
+/// </summary>
+public class BookkeepingObserver : IStatisticsObserver
 {
+    private int _executions;
+    private int _exceptions;
+    private long _totalTimespanTicks;
+
     /// <summary>
-    ///   An IStatisticsObserver which collcts each event
-    ///   internally for later observation.
+    ///   The number of Executions observed by this instance overall.
     /// </summary>
-    public class BookkeepingObserver : IStatisticsObserver
+    public int Executions => _executions;
+
+    /// <summary>
+    ///   The number of Exceptions observed by this instance overall.
+    /// </summary>
+    public int Exceptions => _exceptions;
+
+    /// <summary>
+    ///   The total execution time observed by this instance
+    ///   overall, as a <see cref="TimeSpan" />.
+    /// </summary>
+    public TimeSpan Elapsed => TimeSpan.FromTicks(Interlocked.Read(ref _totalTimespanTicks));
+
+    /// <summary>
+    ///   The last exception observed by this listener.
+    /// </summary>
+    public Exception? LastException { get; private set; }
+
+    /// <summary>
+    ///  Called by a ticker ticker instance when an execution completes
+    /// </summary>
+    /// <param name="statistics">The statistics for the given execution</param>
+    public void OnExecute(Statistics statistics)
     {
-        private int _executions;
-        private int _exceptions;
-        private long _totalTimespanTicks;
+        Interlocked.Add(ref _executions, statistics.Executions);
+        Interlocked.Add(ref _exceptions, statistics.Exceptions);
+        Interlocked.Add(ref _totalTimespanTicks, statistics.Elapsed.Ticks);
+    }
 
-        /// <summary>
-        ///   The number of Executions observed by this instance overall.
-        /// </summary>
-        public int Executions => _executions;
+    /// <summary>
+    ///  Called by a ticker instance when an exception is caught
+    /// </summary>
+    /// <param name="exception">The exception that was observed</param>
+    public void OnException(Exception exception)
+    {
+        LastException = exception;
+    }
 
-        /// <summary>
-        ///   The number of Exceptions observed by this instance overall.
-        /// </summary>
-        public int Exceptions => _exceptions;
-
-        /// <summary>
-        ///   The total execution time observed by this instance
-        ///   overall, as a <see cref="TimeSpan" />.
-        /// </summary>
-        public TimeSpan Elapsed => TimeSpan.FromTicks(Interlocked.Read(ref _totalTimespanTicks));
-
-        /// <summary>
-        ///   The last exception observed by this listener.
-        /// </summary>
-        public Exception? LastException { get; private set; }
-
-        /// <summary>
-        ///  Called by a ticker ticker instance when an execution completes
-        /// </summary>
-        /// <param name="statistics">The statistics for the given execution</param>
-        public void OnExecute(Statistics statistics)
-        {
-            Interlocked.Add(ref _executions, statistics.Executions);
-            Interlocked.Add(ref _exceptions, statistics.Exceptions);
-            Interlocked.Add(ref _totalTimespanTicks, statistics.Elapsed.Ticks);
-        }
-
-        /// <summary>
-        ///  Called by a ticker instance when an exception is caught
-        /// </summary>
-        /// <param name="exception">The exception that was observed</param>
-        public void OnException(Exception exception)
-        {
-            LastException = exception;
-        }
-
-        /// <summary>
-        ///   Get the current state of this observer as a <see
-        ///   cref="Statistics" /> instance.
-        /// </summary>
-        public Statistics IntoStatistics()
-        {
-            int executions = _executions;
-            int exceptions = _exceptions;
-            long ticks = Interlocked.Read(ref _totalTimespanTicks);
-            return new Statistics(executions, exceptions, TimeSpan.FromTicks(ticks), LastException);
-        }
+    /// <summary>
+    ///   Get the current state of this observer as a <see
+    ///   cref="Statistics" /> instance.
+    /// </summary>
+    public Statistics IntoStatistics()
+    {
+        int executions = _executions;
+        int exceptions = _exceptions;
+        long ticks = Interlocked.Read(ref _totalTimespanTicks);
+        return new Statistics(executions, exceptions, TimeSpan.FromTicks(ticks), LastException);
     }
 }

--- a/src/PollyTick/CompositeObserver.cs
+++ b/src/PollyTick/CompositeObserver.cs
@@ -1,43 +1,42 @@
 using System;
 
-namespace PollyTick
+namespace PollyTick;
+
+/// <summary>
+///  A statistics observer that forwards on to a collection
+///  of inner observers.
+/// </summary>
+public class CompositeObserver : IStatisticsObserver
 {
+    private IStatisticsObserver[] _observers;
+
     /// <summary>
-    ///  A statistics observer that forwards on to a collection
-    ///  of inner observers.
+    ///  Create a new observer that wraps the given set of
+    ///  <paramref name="observers" />.
     /// </summary>
-    public class CompositeObserver : IStatisticsObserver
+    /// <param name="observers">The observers to wrap</param>
+    public CompositeObserver(params IStatisticsObserver[] observers)
     {
-        private IStatisticsObserver[] _observers;
+        _observers = observers;
+    }
 
-        /// <summary>
-        ///  Create a new observer that wraps the given set of
-        ///  <paramref name="observers" />.
-        /// </summary>
-        /// <param name="observers">The observers to wrap</param>
-        public CompositeObserver(params IStatisticsObserver[] observers)
-        {
-            _observers = observers;
-        }
+    /// <summary>
+    ///  Called by a ticker ticker instance when an execution completes
+    /// </summary>
+    /// <param name="statistics">The statistics for the given execution</param>
+    public void OnExecute(Statistics statistics)
+    {
+        foreach (var obs in _observers)
+            obs.OnExecute(statistics);
+    }
 
-        /// <summary>
-        ///  Called by a ticker ticker instance when an execution completes
-        /// </summary>
-        /// <param name="statistics">The statistics for the given execution</param>
-        public void OnExecute(Statistics statistics)
-        {
-            foreach (var obs in _observers)
-                obs.OnExecute(statistics);
-        }
-
-        /// <summary>
-        ///  Called by a ticker instance when an exception is caught
-        /// </summary>
-        /// <param name="exception">The exception observed</param>
-        public void OnException(Exception exception)
-        {
-            foreach (var obs in _observers)
-                obs.OnException(exception);
-        }
+    /// <summary>
+    ///  Called by a ticker instance when an exception is caught
+    /// </summary>
+    /// <param name="exception">The exception observed</param>
+    public void OnException(Exception exception)
+    {
+        foreach (var obs in _observers)
+            obs.OnException(exception);
     }
 }

--- a/src/PollyTick/IStatisticsObserver.cs
+++ b/src/PollyTick/IStatisticsObserver.cs
@@ -1,21 +1,20 @@
 using System;
 
-namespace PollyTick
+namespace PollyTick;
+
+/// <summary>
+///   An observer of <see cref="TickerInstance" /> executions.
+/// </summary>
+public interface IStatisticsObserver
 {
     /// <summary>
-    ///   An observer of <see cref="TickerInstance" /> executions.
+    ///   Observes the result of an execution. Called with the statistics
+    ///   from the execution when it completes.
     /// </summary>
-    public interface IStatisticsObserver
-    {
-        /// <summary>
-        ///   Observes the result of an execution. Called with the statistics
-        ///   from the execution when it completes.
-        /// </summary>
-        void OnExecute(Statistics statistics);
+    void OnExecute(Statistics statistics);
 
-        /// <summary>
-        ///   Observes an Exception during execution
-        /// </summary>
-        void OnException(Exception exception);
-    }
+    /// <summary>
+    ///   Observes an Exception during execution
+    /// </summary>
+    void OnException(Exception exception);
 }

--- a/src/PollyTick/NullObserver.cs
+++ b/src/PollyTick/NullObserver.cs
@@ -1,27 +1,26 @@
 using System;
 
-namespace PollyTick
-{
-    /// <statistics>
-    ///   An <see cref="IStatisticsObserver" /> insttance which does
-    ///   nothing.
-    /// </statistics>
-    public class NullObserver : IStatisticsObserver
-    {
-        /// <summary>
-        /// Does nothing when the statistics from an execution
-        /// </summary>
-        /// <param name="statistics">The statistics to ignore</param>
-        public void OnExecute(Statistics statistics)
-        {
-        }
+namespace PollyTick;
 
-        /// <summary>
-        ///  Does nothing with an exception observed during execution.
-        /// </summary>
-        /// <param name="exception">The exception to ignore</param>
-        public void OnException(Exception exception)
-        {
-        }
+/// <statistics>
+///   An <see cref="IStatisticsObserver" /> insttance which does
+///   nothing.
+/// </statistics>
+public class NullObserver : IStatisticsObserver
+{
+    /// <summary>
+    /// Does nothing when the statistics from an execution
+    /// </summary>
+    /// <param name="statistics">The statistics to ignore</param>
+    public void OnExecute(Statistics statistics)
+    {
+    }
+
+    /// <summary>
+    ///  Does nothing with an exception observed during execution.
+    /// </summary>
+    /// <param name="exception">The exception to ignore</param>
+    public void OnException(Exception exception)
+    {
     }
 }

--- a/src/PollyTick/PollyTick.csproj
+++ b/src/PollyTick/PollyTick.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>0.6.0</VersionPrefix>
-    <TargetFrameworks>netstandard1.1;netstandard2.1</TargetFrameworks>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>PollyTick</AssemblyName>
     <PackageId>PollyTick</PackageId>

--- a/src/PollyTick/Statistics.cs
+++ b/src/PollyTick/Statistics.cs
@@ -1,75 +1,74 @@
 using System;
 
-namespace PollyTick
+namespace PollyTick;
+
+/// <summary>
+///   Statistics calculated from a Ticker execution. Each time a
+///   TickerInstance is executed a Statistics instance is returned
+///   to keep track of what happened.
+/// </summary>
+public class Statistics
 {
     /// <summary>
-    ///   Statistics calculated from a Ticker execution. Each time a
-    ///   TickerInstance is executed a Statistics instance is returned
-    ///   to keep track of what happened.
+    ///  Create a new statistics instance
     /// </summary>
-    public class Statistics
+    /// <param name="executions">The number of excecutions this statistics object covers</param>
+    /// <param name="exceptions">The number of exceptions observed</param>
+    /// <param name="elapsed">The total elapsed time observed</param>
+    /// <param name="finalException">The last exception observed, if any</param>
+    public Statistics(int executions, int exceptions, TimeSpan elapsed, Exception? finalException)
     {
-        /// <summary>
-        ///  Create a new statistics instance
-        /// </summary>
-        /// <param name="executions">The number of excecutions this statistics object covers</param>
-        /// <param name="exceptions">The number of exceptions observed</param>
-        /// <param name="elapsed">The total elapsed time observed</param>
-        /// <param name="finalException">The last exception observed, if any</param>
-        public Statistics(int executions, int exceptions, TimeSpan elapsed, Exception? finalException)
-        {
-            Executions = executions;
-            Exceptions = exceptions;
-            Elapsed = elapsed;
-			FinalException = finalException;
-        }
-
-        /// <summary>
-        ///   Returns the number of executions that this statistics
-        ///   instance is for.
-        /// </summary>
-        public int Executions { get; }
-
-        /// <summary>
-        ///   Returns the number of exceptions encountered during the
-        ///   excecutions this instance is for.
-        /// </summary>
-        public int Exceptions { get; }
-
-        /// <summary>
-        ///   The total elapsed time for all executions.
-        /// </summary>
-        public TimeSpan Elapsed { get; }
-
-		/// <summary>
-		///   The final exception seen by this statistics, if any.
-		/// </summary>
-		public Exception? FinalException { get; }
+        Executions = executions;
+        Exceptions = exceptions;
+        Elapsed = elapsed;
+        FinalException = finalException;
     }
 
     /// <summary>
-    ///   Statistics about a policy execution with a return value.
+    ///   Returns the number of executions that this statistics
+    ///   instance is for.
     /// </summary>
-    public class Statistics<T> : Statistics
-    {
-        /// <summary>
-        ///  Create a new statistics instance, with a result value.
-        /// </summary>
-        /// <param name="executions">The number of excecutions this statistics object covers</param>
-        /// <param name="exceptions">The number of exceptions observed</param>
-        /// <param name="elapsed">The total elapsed time observed</param>
-        /// <param name="finalException">The last exception observed, if any</param>
-        /// <param name="result">The result of the execution</param>
-        public Statistics(int executions, int exceptions, TimeSpan elapsed, Exception? finalException, T? result)
-            : base(executions, exceptions, elapsed, finalException)
-        {
-            Result = result;
-        }
+    public int Executions { get; }
 
-        /// <summary>
-        ///   The result of the operation, if it completed
-        ///   successfully.
-        /// </summary>
-        public T? Result { get; }
+    /// <summary>
+    ///   Returns the number of exceptions encountered during the
+    ///   excecutions this instance is for.
+    /// </summary>
+    public int Exceptions { get; }
+
+    /// <summary>
+    ///   The total elapsed time for all executions.
+    /// </summary>
+    public TimeSpan Elapsed { get; }
+
+    /// <summary>
+    ///   The final exception seen by this statistics, if any.
+    /// </summary>
+    public Exception? FinalException { get; }
+}
+
+/// <summary>
+///   Statistics about a policy execution with a return value.
+/// </summary>
+public class Statistics<T> : Statistics
+{
+    /// <summary>
+    ///  Create a new statistics instance, with a result value.
+    /// </summary>
+    /// <param name="executions">The number of excecutions this statistics object covers</param>
+    /// <param name="exceptions">The number of exceptions observed</param>
+    /// <param name="elapsed">The total elapsed time observed</param>
+    /// <param name="finalException">The last exception observed, if any</param>
+    /// <param name="result">The result of the execution</param>
+    public Statistics(int executions, int exceptions, TimeSpan elapsed, Exception? finalException, T? result)
+        : base(executions, exceptions, elapsed, finalException)
+    {
+        Result = result;
     }
+
+    /// <summary>
+    ///   The result of the operation, if it completed
+    ///   successfully.
+    /// </summary>
+    public T? Result { get; }
 }

--- a/src/PollyTick/SyncTickerInstanceBase.cs
+++ b/src/PollyTick/SyncTickerInstanceBase.cs
@@ -1,40 +1,39 @@
 using System;
 using System.Diagnostics;
 
-namespace PollyTick
+namespace PollyTick;
+
+/// <summary>
+///   Base class for all synchronous ticker instances
+/// </summary>
+public class SyncTickerInstanceBase : TickerInstanceBase
 {
     /// <summary>
-    ///   Base class for all synchronous ticker instances
+    ///   Internal implementation of the `ExecuteNoCapture`.
     /// </summary>
-    public class SyncTickerInstanceBase : TickerInstanceBase
+    protected T ExecuteNoCaptureInternal<T>(Func<T> action, IStatisticsObserver observer)
     {
-        /// <summary>
-        ///   Internal implementation of the `ExecuteNoCapture`.
-        /// </summary>
-        protected T ExecuteNoCaptureInternal<T>(Func<T> action, IStatisticsObserver observer)
+        var sw = Stopwatch.StartNew();
+        int exceptions = 0;
+        T? result = default(T);
+        Exception? capturedException = null;
+        try
         {
-            var sw = Stopwatch.StartNew();
-            int exceptions = 0;
-            T? result = default(T);
-			Exception? capturedException = null;
-            try
-            {
-                result = action();
-                return result;
-            }
-            catch (Exception e)
-            {
-                OnException(e, observer);
-				capturedException = e;
-                exceptions++;
-                throw;
-            }
-            finally
-            {
-                sw.Stop();
-                var stats = new Statistics<T>(1, exceptions, sw.Elapsed, capturedException, result);
-                OnExecute(stats, observer);
-            }
+            result = action();
+            return result;
+        }
+        catch (Exception e)
+        {
+            OnException(e, observer);
+            capturedException = e;
+            exceptions++;
+            throw;
+        }
+        finally
+        {
+            sw.Stop();
+            var stats = new Statistics<T>(1, exceptions, sw.Elapsed, capturedException, result);
+            OnExecute(stats, observer);
         }
     }
 }

--- a/src/PollyTick/SyncTickerInstanceBase.cs
+++ b/src/PollyTick/SyncTickerInstanceBase.cs
@@ -13,17 +13,20 @@ public class SyncTickerInstanceBase : TickerInstanceBase
     /// </summary>
     protected T ExecuteNoCaptureInternal<T>(Func<T> action, IStatisticsObserver observer)
     {
-        var sw = Stopwatch.StartNew();
+        var start = Stopwatch.GetTimestamp();
+        var end = start;
         int exceptions = 0;
         T? result = default(T);
         Exception? capturedException = null;
         try
         {
             result = action();
+            end = Stopwatch.GetTimestamp();
             return result;
         }
         catch (Exception e)
         {
+            end = Stopwatch.GetTimestamp();
             OnException(e, observer);
             capturedException = e;
             exceptions++;
@@ -31,8 +34,7 @@ public class SyncTickerInstanceBase : TickerInstanceBase
         }
         finally
         {
-            sw.Stop();
-            var stats = new Statistics<T>(1, exceptions, sw.Elapsed, capturedException, result);
+            var stats = new Statistics<T>(1, exceptions, TimeSpanFromTicks(end - start), capturedException, result);
             OnExecute(stats, observer);
         }
     }

--- a/src/PollyTick/Ticker.cs
+++ b/src/PollyTick/Ticker.cs
@@ -1,57 +1,56 @@
 ﻿using Polly;
 using System.ComponentModel;
 
-namespace PollyTick
+namespace PollyTick;
+
+/// <summary>
+///  Factory methods for creating ticker instances
+/// </summary>
+public static class Ticker
 {
     /// <summary>
-    ///  Factory methods for creating ticker instances
+    ///   Create a ticker instance wrapping a synchronous policy
+    ///   with no return value.
     /// </summary>
-    public static class Ticker
+    /// <param name="policy">The policy to wrap</param>
+    /// <returns>A ticker instance to observe policy excecutions</returns>
+    public static TickerInstance WithPolicy(ISyncPolicy policy)
     {
-        /// <summary>
-        ///   Create a ticker instance wrapping a synchronous policy
-        ///   with no return value.
-        /// </summary>
-        /// <param name="policy">The policy to wrap</param>
-        /// <returns>A ticker instance to observe policy excecutions</returns>
-        public static TickerInstance WithPolicy(ISyncPolicy policy)
-        {
-            return new TickerInstance(policy);
-        }
+        return new TickerInstance(policy);
+    }
 
-        /// <summary>
-        ///   Create a ticker instance wrapping a synchronous policy
-        ///   which returns <typeparamref name="T" />.
-        /// </summary>
-        /// <param name="policy">The policy to wrap</param>
-        /// <typeparam name="T">The return type of the policy execution</typeparam>
-        /// <returns>A ticker instance to observe policy excecutions</returns>
-        public static TickerInstance<T> WithPolicy<T>(ISyncPolicy<T> policy)
-        {
-            return new TickerInstance<T>(policy);
-        }
+    /// <summary>
+    ///   Create a ticker instance wrapping a synchronous policy
+    ///   which returns <typeparamref name="T" />.
+    /// </summary>
+    /// <param name="policy">The policy to wrap</param>
+    /// <typeparam name="T">The return type of the policy execution</typeparam>
+    /// <returns>A ticker instance to observe policy excecutions</returns>
+    public static TickerInstance<T> WithPolicy<T>(ISyncPolicy<T> policy)
+    {
+        return new TickerInstance<T>(policy);
+    }
 
-        /// <summary>
-        ///   Create a ticker instance wrapping an asynchronous policy
-        ///   with no return value.
-        /// </summary>
-        /// <param name="policy">The policy to wrap</param>
-        /// <returns>A ticker instance to observe policy excecutions</returns>
-        public static AsyncTickerInstance WithPolicy(IAsyncPolicy policy)
-        {
-            return new AsyncTickerInstance(policy);
-        }
+    /// <summary>
+    ///   Create a ticker instance wrapping an asynchronous policy
+    ///   with no return value.
+    /// </summary>
+    /// <param name="policy">The policy to wrap</param>
+    /// <returns>A ticker instance to observe policy excecutions</returns>
+    public static AsyncTickerInstance WithPolicy(IAsyncPolicy policy)
+    {
+        return new AsyncTickerInstance(policy);
+    }
 
-        /// <summary>
-        ///   Create a ticker instance wrapping an asynchronous policy
-        ///   which returns <typeparamref name="T" />.
-        /// </summary>
-        /// <param name="policy">The policy to wrap</param>
-        /// <typeparam name="T">The return type of the policy execution</typeparam>
-        /// <returns>A ticker instance to observe policy excecutions</returns>
-        public static AsyncTickerInstance<T> WithPolicy<T>(IAsyncPolicy<T> policy)
-        {
-            return new AsyncTickerInstance<T>(policy);
-        }
+    /// <summary>
+    ///   Create a ticker instance wrapping an asynchronous policy
+    ///   which returns <typeparamref name="T" />.
+    /// </summary>
+    /// <param name="policy">The policy to wrap</param>
+    /// <typeparam name="T">The return type of the policy execution</typeparam>
+    /// <returns>A ticker instance to observe policy excecutions</returns>
+    public static AsyncTickerInstance<T> WithPolicy<T>(IAsyncPolicy<T> policy)
+    {
+        return new AsyncTickerInstance<T>(policy);
     }
 }

--- a/src/PollyTick/TickerInstance.TResult.cs
+++ b/src/PollyTick/TickerInstance.TResult.cs
@@ -4,60 +4,59 @@ using System.Diagnostics;
 using Polly;
 using System.Threading;
 
-namespace PollyTick
+namespace PollyTick;
+
+/// <summary>
+///  A ticker instance which observes an <see cref="ISyncPolicy{T}" />.
+/// </summary>
+public class TickerInstance<T> : SyncTickerInstanceBase
 {
-    /// <summary>
-    ///  A ticker instance which observes an <see cref="ISyncPolicy{T}" />.
-    /// </summary>
-    public class TickerInstance<T> : SyncTickerInstanceBase
+    private ISyncPolicy<T> _policy;
+
+    internal TickerInstance(ISyncPolicy<T> policy)
     {
-        private ISyncPolicy<T> _policy;
+        _policy = policy;
+    }
 
-        internal TickerInstance(ISyncPolicy<T> policy)
-        {
-            _policy = policy;
-        }
+    /// <summary>
+    ///   Register a statistics observer. The observer will be called
+    ///   for all executions of this TickerInstance.
+    /// </summary>
+    public TickerInstance<T> WithObserver(IStatisticsObserver observer)
+    {
+        AddObserver(observer);
+        return this;
+    }
 
-        /// <summary>
-        ///   Register a statistics observer. The observer will be called
-        ///   for all executions of this TickerInstance.
-        /// </summary>
-        public TickerInstance<T> WithObserver(IStatisticsObserver observer)
-        {
-            AddObserver(observer);
-            return this;
-        }
+    /// <summary>
+    ///  Execute the instrumented body, returning the execution
+    ///  statistics and execution result.
+    /// </summary>
+    public Statistics<T> Execute(Func<T> action)
+    {
+        return Execute(action, new NullObserver());
+    }
 
-        /// <summary>
-        ///  Execute the instrumented body, returning the execution
-        ///  statistics and execution result.
-        /// </summary>
-        public Statistics<T> Execute(Func<T> action)
-        {
-            return Execute(action, new NullObserver());
-        }
+    /// <summary>
+    ///   Execute the instrumented body with a statistics observer,
+    ///   returning the execution statistics. The statistics observer
+    ///   will receive a callback with the outcome of the execution.
+    /// </summary>
+    public Statistics<T> Execute(Func<T> action, IStatisticsObserver observer)
+    {
+        var start = Stopwatch.GetTimestamp();
+        var result = _policy.ExecuteAndCapture(action);
+        var end = Stopwatch.GetTimestamp();
 
-        /// <summary>
-        ///   Execute the instrumented body with a statistics observer,
-        ///   returning the execution statistics. The statistics observer
-        ///   will receive a callback with the outcome of the execution.
-        /// </summary>
-        public Statistics<T> Execute(Func<T> action, IStatisticsObserver observer)
-        {
-            var start = Stopwatch.GetTimestamp();
-            var result = _policy.ExecuteAndCapture(action);
-            var end = Stopwatch.GetTimestamp();
+        return StatisticsFromResult(result, TimeSpanFromTicks(end - start), observer);
+    }
 
-            return StatisticsFromResult(result, TimeSpanFromTicks(end - start), observer);
-        }
-
-        /// <summary>
-        ///   Execute the Instrumented body without capturing
-        ///   exceptions or intercepting the result.
-        /// </summary>
-        public T ExecuteNoCapture(Func<T> action, IStatisticsObserver observer)
-        {
-            return ExecuteNoCaptureInternal(() => _policy.Execute(action), observer);
-        }
+    /// <summary>
+    ///   Execute the Instrumented body without capturing
+    ///   exceptions or intercepting the result.
+    /// </summary>
+    public T ExecuteNoCapture(Func<T> action, IStatisticsObserver observer)
+    {
+        return ExecuteNoCaptureInternal(() => _policy.Execute(action), observer);
     }
 }

--- a/src/PollyTick/TickerInstance.TResult.cs
+++ b/src/PollyTick/TickerInstance.TResult.cs
@@ -44,11 +44,11 @@ namespace PollyTick
         /// </summary>
         public Statistics<T> Execute(Func<T> action, IStatisticsObserver observer)
         {
-            var sw = Stopwatch.StartNew();
+            var start = Stopwatch.GetTimestamp();
             var result = _policy.ExecuteAndCapture(action);
-            sw.Stop();
+            var end = Stopwatch.GetTimestamp();
 
-            return StatisticsFromResult(result, sw, observer);
+            return StatisticsFromResult(result, TimeSpanFromTicks(end - start), observer);
         }
 
         /// <summary>

--- a/src/PollyTick/TickerInstance.cs
+++ b/src/PollyTick/TickerInstance.cs
@@ -72,11 +72,11 @@ namespace PollyTick
         /// </summary>
         public Statistics<T> Execute<T>(Func<T> action, IStatisticsObserver observer)
         {
-            var sw = Stopwatch.StartNew();
+            var start = Stopwatch.GetTimestamp();
             var result = _policy.ExecuteAndCapture(action);
-            sw.Stop();
+            var end = Stopwatch.GetTimestamp();
             
-            return StatisticsFromResult(result, sw, observer);
+            return StatisticsFromResult(result, TimeSpanFromTicks(end - start), observer);
         }
 
         /// <summary>

--- a/src/PollyTick/TickerInstance.cs
+++ b/src/PollyTick/TickerInstance.cs
@@ -4,88 +4,87 @@ using System.Diagnostics;
 using Polly;
 using System.Threading;
 
-namespace PollyTick
+namespace PollyTick;
+
+/// <summary>
+///  A ticker instance which observes an <see cref="ISyncPolicy" />.
+/// </summary>
+public class TickerInstance : SyncTickerInstanceBase
 {
-    /// <summary>
-    ///  A ticker instance which observes an <see cref="ISyncPolicy" />.
-    /// </summary>
-    public class TickerInstance : SyncTickerInstanceBase
+    private ISyncPolicy _policy;
+
+    internal TickerInstance(ISyncPolicy policy)
     {
-        private ISyncPolicy _policy;
+        _policy = policy;
+    }
 
-        internal TickerInstance(ISyncPolicy policy)
-        {
-            _policy = policy;
-        }
+    /// <summary>
+    ///   Register a statistics observer. The observer will be called
+    ///   for all executions of this TickerInstance.
+    /// </summary>
+    public TickerInstance WithObserver(IStatisticsObserver observer)
+    {
+        AddObserver(observer);
+        return this;
+    }
 
-        /// <summary>
-        ///   Register a statistics observer. The observer will be called
-        ///   for all executions of this TickerInstance.
-        /// </summary>
-        public TickerInstance WithObserver(IStatisticsObserver observer)
-        {
-            AddObserver(observer);
-            return this;
-        }
+    /// <summary>
+    ///   Execute the instrumented body, returning the execution
+    ///   statistics for this execution.
+    /// </summary>
+    public Statistics Execute(Action action)
+    {
+        return Execute(action, new NullObserver());
+    }
 
-        /// <summary>
-        ///   Execute the instrumented body, returning the execution
-        ///   statistics for this execution.
-        /// </summary>
-        public Statistics Execute(Action action)
-        {
-            return Execute(action, new NullObserver());
-        }
+    /// <summary>
+    ///   Execute the instrumented body with a statistics observer,
+    ///   returning the execution statistics. The statistics observer
+    ///   will receive a callback with the outcome of the execution.
+    /// </summary>
+    public Statistics Execute(Action action, IStatisticsObserver observer)
+    {
+        return Execute(() => { action(); return 0; }, observer);
+    }
 
-        /// <summary>
-        ///   Execute the instrumented body with a statistics observer,
-        ///   returning the execution statistics. The statistics observer
-        ///   will receive a callback with the outcome of the execution.
-        /// </summary>
-        public Statistics Execute(Action action, IStatisticsObserver observer)
-        {
-            return Execute(() => { action(); return 0; }, observer);
-        }
+    /// <summary>
+    ///   Execute the Instrumented body without capturing
+    ///   exceptions or intercepting the result.
+    /// </summary>
+    public void ExecuteNoCapture(Action action, IStatisticsObserver observer)
+    {
+        ExecuteNoCapture(() => { action(); return 0; }, observer);
+    }
 
-        /// <summary>
-        ///   Execute the Instrumented body without capturing
-        ///   exceptions or intercepting the result.
-        /// </summary>
-        public void ExecuteNoCapture(Action action, IStatisticsObserver observer)
-        {
-            ExecuteNoCapture(() => { action(); return 0; }, observer);
-        }
+    /// <summary>
+    ///  Execute the instrumented body, returning the execution
+    ///  statistics and execution result.
+    /// </summary>
+    public Statistics<T> Execute<T>(Func<T> action)
+    {
+        return Execute(action, new NullObserver());
+    }
 
-        /// <summary>
-        ///  Execute the instrumented body, returning the execution
-        ///  statistics and execution result.
-        /// </summary>
-        public Statistics<T> Execute<T>(Func<T> action)
-        {
-            return Execute(action, new NullObserver());
-        }
+    /// <summary>
+    ///   Execute the instrumented body with a statistics observer,
+    ///   returning the execution statistics. The statistics observer
+    ///   will receive a callback with the outcome of the execution.
+    /// </summary>
+    public Statistics<T> Execute<T>(Func<T> action, IStatisticsObserver observer)
+    {
+        var start = Stopwatch.GetTimestamp();
+        var result = _policy.ExecuteAndCapture(action);
+        var end = Stopwatch.GetTimestamp();
 
-        /// <summary>
-        ///   Execute the instrumented body with a statistics observer,
-        ///   returning the execution statistics. The statistics observer
-        ///   will receive a callback with the outcome of the execution.
-        /// </summary>
-        public Statistics<T> Execute<T>(Func<T> action, IStatisticsObserver observer)
-        {
-            var start = Stopwatch.GetTimestamp();
-            var result = _policy.ExecuteAndCapture(action);
-            var end = Stopwatch.GetTimestamp();
-            
-            return StatisticsFromResult(result, TimeSpanFromTicks(end - start), observer);
-        }
+        return StatisticsFromResult(result, TimeSpanFromTicks(end - start), observer);
+    }
 
-        /// <summary>
-        ///   Execute the Instrumented body without capturing
-        ///   exceptions or intercepting the result.
-        /// </summary>
-        public T ExecuteNoCapture<T>(Func<T> action, IStatisticsObserver observer)
-        {
-            return ExecuteNoCaptureInternal(() => _policy.Execute(action), observer);
-        }
+    /// <summary>
+    ///   Execute the Instrumented body without capturing
+    ///   exceptions or intercepting the result.
+    /// </summary>
+    public T ExecuteNoCapture<T>(Func<T> action, IStatisticsObserver observer)
+    {
+        return ExecuteNoCaptureInternal(() => _policy.Execute(action), observer);
     }
 }

--- a/src/PollyTick/TickerInstanceBase.cs
+++ b/src/PollyTick/TickerInstanceBase.cs
@@ -36,11 +36,11 @@ namespace PollyTick
         /// </summary>
         protected Statistics<TResult> StatisticsFromResult<TResult>(
             PolicyResult<TResult> result,
-            Stopwatch sw,
+            TimeSpan elapsed,
             IStatisticsObserver observer)
         {
             var failures = result.Outcome == OutcomeType.Successful ? 0 : 1;
-            var stats = new Statistics<TResult>(1, failures, sw.Elapsed, result.FinalException, result.Result);
+            var stats = new Statistics<TResult>(1, failures, elapsed, result.FinalException, result.Result);
 
             if (result.FinalException != null)
             {
@@ -79,5 +79,13 @@ namespace PollyTick
                 obs.OnException(exception);
             }
         }
+
+        /// <summary>Convert stopwatch ticks into a timespan</summary>
+        protected static TimeSpan TimeSpanFromTicks(long ticks)
+        {
+            return TimeSpan.FromTicks((long)(ticks * s_tickCoefficient));
+        }
+
+        private static double s_tickCoefficient = (double)TimeSpan.TicksPerSecond / Stopwatch.Frequency;
     }
 }

--- a/src/PollyTick/TickerInstanceBase.cs
+++ b/src/PollyTick/TickerInstanceBase.cs
@@ -5,87 +5,86 @@ using System.Threading;
 using System.Threading.Tasks;
 using Polly;
 
-namespace PollyTick
+namespace PollyTick;
+
+/// <summary>
+///  The base class for all ticker instances
+/// </summary>
+public abstract class TickerInstanceBase
 {
+    private List<IStatisticsObserver> _observers;
+
     /// <summary>
-    ///  The base class for all ticker instances
+    ///  Create an instance of a ticker instance
     /// </summary>
-    public abstract class TickerInstanceBase
+    protected TickerInstanceBase()
     {
-        private List<IStatisticsObserver> _observers;
-        
-        /// <summary>
-        ///  Create an instance of a ticker instance
-        /// </summary>
-        protected TickerInstanceBase()
-        {
-            _observers = new List<IStatisticsObserver>(3);
-        }
-
-        /// <summary>
-        ///   Add a global observer to this ticker instance.
-        /// </summary>
-        protected void AddObserver(IStatisticsObserver observer)
-        {
-            _observers.Add(observer);
-        }
-        
-        /// <summary>
-        ///   Convert a Polly `ExecutionResult` into an instance of
-        ///   our `Statistics` class.
-        /// </summary>
-        protected Statistics<TResult> StatisticsFromResult<TResult>(
-            PolicyResult<TResult> result,
-            TimeSpan elapsed,
-            IStatisticsObserver observer)
-        {
-            var failures = result.Outcome == OutcomeType.Successful ? 0 : 1;
-            var stats = new Statistics<TResult>(1, failures, elapsed, result.FinalException, result.Result);
-
-            if (result.FinalException != null)
-            {
-                OnException(result.FinalException, observer);
-            }
-
-            OnExecute(stats, observer);
-
-            return stats;
-        }
-
-        /// <summary>
-        /// Notify observers of the result of an excecution
-        /// </summary>
-        /// <param name="stats">The statistics for the execution</param>
-        /// <param name="observer">An immediate observer to also notify</param>
-        protected void OnExecute(Statistics stats, IStatisticsObserver observer)
-        {
-            observer.OnExecute(stats);
-            foreach (var obs in _observers)
-            {
-                obs.OnExecute(stats);
-            }
-        }
-
-        /// <summary>
-        /// Notify observers of an exception
-        /// </summary>
-        /// <param name="exception">The exceptions observed</param>
-        /// <param name="observer">An immediate observer to also notify</param>
-        protected void OnException(Exception exception, IStatisticsObserver observer)
-        {
-            observer.OnException(exception);
-            foreach (var obs in _observers)
-            {
-                obs.OnException(exception);
-            }
-        }
-
-        /// <summary>Convert stopwatch ticks into a timespan</summary>
-        protected static TimeSpan TimeSpanFromTicks(long ticks)
-        {
-            return TimeSpan.FromTicks((long)(ticks * s_tickCoefficient));
-        }
-
-        private static double s_tickCoefficient = (double)TimeSpan.TicksPerSecond / Stopwatch.Frequency;
+        _observers = new List<IStatisticsObserver>(3);
     }
+
+    /// <summary>
+    ///   Add a global observer to this ticker instance.
+    /// </summary>
+    protected void AddObserver(IStatisticsObserver observer)
+    {
+        _observers.Add(observer);
+    }
+
+    /// <summary>
+    ///   Convert a Polly `ExecutionResult` into an instance of
+    ///   our `Statistics` class.
+    /// </summary>
+    protected Statistics<TResult> StatisticsFromResult<TResult>(
+        PolicyResult<TResult> result,
+        TimeSpan elapsed,
+        IStatisticsObserver observer)
+    {
+        var failures = result.Outcome == OutcomeType.Successful ? 0 : 1;
+        var stats = new Statistics<TResult>(1, failures, elapsed, result.FinalException, result.Result);
+
+        if (result.FinalException != null)
+        {
+            OnException(result.FinalException, observer);
+        }
+
+        OnExecute(stats, observer);
+
+        return stats;
+    }
+
+    /// <summary>
+    /// Notify observers of the result of an excecution
+    /// </summary>
+    /// <param name="stats">The statistics for the execution</param>
+    /// <param name="observer">An immediate observer to also notify</param>
+    protected void OnExecute(Statistics stats, IStatisticsObserver observer)
+    {
+        observer.OnExecute(stats);
+        foreach (var obs in _observers)
+        {
+            obs.OnExecute(stats);
+        }
+    }
+
+    /// <summary>
+    /// Notify observers of an exception
+    /// </summary>
+    /// <param name="exception">The exceptions observed</param>
+    /// <param name="observer">An immediate observer to also notify</param>
+    protected void OnException(Exception exception, IStatisticsObserver observer)
+    {
+        observer.OnException(exception);
+        foreach (var obs in _observers)
+        {
+            obs.OnException(exception);
+        }
+    }
+
+    /// <summary>Convert stopwatch ticks into a timespan</summary>
+    protected static TimeSpan TimeSpanFromTicks(long ticks)
+    {
+        return TimeSpan.FromTicks((long)(ticks * s_tickCoefficient));
+    }
+
+    private static double s_tickCoefficient = (double)TimeSpan.TicksPerSecond / Stopwatch.Frequency;
 }

--- a/test/PollyTick.Tests/CompositeObserverTests.cs
+++ b/test/PollyTick.Tests/CompositeObserverTests.cs
@@ -2,39 +2,38 @@ using System;
 using PollyTick;
 using Xunit;
 
-namespace PollyTickTests
+namespace PollyTickTests;
+
+public class CompositeObserverTests
 {
-    public class CompositeObserverTests
+    [Fact]
+    public void Composite_OnExecute_CallsAllChildObservers()
     {
-        [Fact]
-        public void Composite_OnExecute_CallsAllChildObservers()
-        {
-            var book1 = new BookkeepingObserver();
-            var book2 = new BookkeepingObserver();
-            var observer = new CompositeObserver(book1, book2);
-                                                 
-            observer.OnExecute(new Statistics(1, 2, TimeSpan.FromSeconds(3), new Exception("hello")));
+        var book1 = new BookkeepingObserver();
+        var book2 = new BookkeepingObserver();
+        var observer = new CompositeObserver(book1, book2);
 
-            Assert.Equal(1, book1.Executions);
-            Assert.Equal(1, book2.Executions);
-            Assert.Equal(2, book1.Exceptions);
-            Assert.Equal(2, book2.Exceptions);
-            Assert.Equal(3, book1.Elapsed.TotalSeconds);
-            Assert.Equal(3, book2.Elapsed.TotalSeconds);
-        }
+        observer.OnExecute(new Statistics(1, 2, TimeSpan.FromSeconds(3), new Exception("hello")));
 
-        [Fact]
-        public void Composite_OnException_AllChildObserversReceiveException()
-        {
-            var book1 = new BookkeepingObserver();
-            var book2 = new BookkeepingObserver();
-            var observer = new CompositeObserver(book1, book2);
-                                                 
-            var ex = new NotSupportedException();
-            observer.OnException(ex);
+        Assert.Equal(1, book1.Executions);
+        Assert.Equal(1, book2.Executions);
+        Assert.Equal(2, book1.Exceptions);
+        Assert.Equal(2, book2.Exceptions);
+        Assert.Equal(3, book1.Elapsed.TotalSeconds);
+        Assert.Equal(3, book2.Elapsed.TotalSeconds);
+    }
 
-            Assert.Equal(ex, book1.LastException);
-            Assert.Equal(ex, book2.LastException);
-        }
+    [Fact]
+    public void Composite_OnException_AllChildObserversReceiveException()
+    {
+        var book1 = new BookkeepingObserver();
+        var book2 = new BookkeepingObserver();
+        var observer = new CompositeObserver(book1, book2);
+
+        var ex = new NotSupportedException();
+        observer.OnException(ex);
+
+        Assert.Equal(ex, book1.LastException);
+        Assert.Equal(ex, book2.LastException);
     }
 }

--- a/test/PollyTick.Tests/PollyTick.Tests.csproj
+++ b/test/PollyTick.Tests/PollyTick.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/test/PollyTick.Tests/TickerTests.cs
+++ b/test/PollyTick.Tests/TickerTests.cs
@@ -6,361 +6,361 @@ using Xunit;
 using Polly;
 using PollyTick;
 
-namespace PollyTickTests
+namespace PollyTickTests;
+
+public class Tests
 {
-    public class Tests
+    [Fact]
+    public void Ticker_Execute_ExecutesDelegate()
     {
-        [Fact]
-        public void Ticker_Execute_ExecutesDelegate()
+        var foo = false;
+        Ticker
+            .WithPolicy(Policy.NoOp())
+            .Execute(() => foo = true);
+        Assert.True(foo);
+    }
+
+    [Fact]
+    public void Ticker_Execute_ReturnsExecutionStats()
+    {
+        var ticker = Ticker
+            .WithPolicy(Policy.NoOp());
+
+        var stats = ticker.Execute(() => { });
+        Assert.Equal(1, stats.Executions);
+        Assert.Equal(0, stats.Exceptions);
+
+        stats = ticker.Execute(() => { });
+        Assert.Equal(1, stats.Executions);
+        Assert.Equal(0, stats.Exceptions);
+    }
+
+    [Fact]
+    public void Ticker_ExecuteWithException_StatisticsShowException()
+    {
+        var ticker = Ticker
+            .WithPolicy(Policy.NoOp());
+
+        var stats = ticker.Execute(() => { throw new Exception(); });
+
+        Assert.Equal(1, stats.Exceptions);
+    }
+
+    [Fact]
+    public void Ticker_WhenBodyTakesTime_TimeIsRecorded()
+    {
+        var stats = Ticker
+            .WithPolicy(Policy.NoOp())
+            .Execute(() => Thread.Sleep(TimeSpan.FromSeconds(0.1)));
+        Assert.Equal(1, stats.Executions);
+        Assert.Equal(0, stats.Exceptions);
+        Assert.NotEqual(TimeSpan.Zero, stats.Elapsed);
+    }
+
+    [Fact]
+    public void Ticker_WhenBodyReturnsValue_ValueIsAvailable()
+    {
+        var ticker = Ticker
+            .WithPolicy(Policy.NoOp());
+
+        var stats = ticker.Execute(() => 1337);
+        Assert.Equal(1337, stats.Result);
+
+        stats = ticker.Execute(() => -9000);
+        Assert.Equal(-9000, stats.Result);
+
+        var boolStats = ticker.Execute(() => false);
+        Assert.False(boolStats.Result);
+    }
+
+    [Fact]
+    public void Ticker_WhenPolicyHasKnownReturnType_PolicyCanBeUsed()
+    {
+        var i = 100;
+        var policy = Policy
+            .HandleResult(100)
+            .Retry();
+        var ticker = Ticker
+            .WithPolicy(policy);
+
+        var stats1 = ticker.Execute(() => i++);
+        var stats2 = ticker.Execute(() => i++);
+
+        Assert.Equal(101, stats1.Result);
+        Assert.Equal(102, stats2.Result);
+    }
+
+    [Fact]
+    public async Task Ticker_WithAsyncBody_ExecutesBody()
+    {
+        var ticker = Ticker
+            .WithPolicy(Policy.NoOpAsync());
+
         {
-            var foo = false;
-            Ticker
-                .WithPolicy(Policy.NoOp())
-                .Execute(() => foo = true);
-            Assert.True(foo);
-        }
-
-        [Fact]
-        public void Ticker_Execute_ReturnsExecutionStats()
-        {
-            var ticker = Ticker
-                .WithPolicy(Policy.NoOp());
-
-            var stats = ticker.Execute(() => {});
-            Assert.Equal(1, stats.Executions);
-            Assert.Equal(0, stats.Exceptions);
-
-            stats = ticker.Execute(() => {});
-            Assert.Equal(1, stats.Executions);
-            Assert.Equal(0, stats.Exceptions);
-        }
-
-        [Fact]
-        public void Ticker_ExecuteWithException_StatisticsShowException()
-        {
-            var ticker = Ticker
-                .WithPolicy(Policy.NoOp());
-
-            var stats = ticker.Execute(() => { throw new Exception(); });
-
-            Assert.Equal(1, stats.Exceptions);
-        }
-
-        [Fact]
-        public void Ticker_WhenBodyTakesTime_TimeIsRecorded()
-        {
-            var stats = Ticker
-                .WithPolicy(Policy.NoOp())
-                .Execute(() => Thread.Sleep(TimeSpan.FromSeconds(0.1)));
+            var stats = await ticker.ExecuteAsync(() => Task.Delay(100));
             Assert.Equal(1, stats.Executions);
             Assert.Equal(0, stats.Exceptions);
             Assert.NotEqual(TimeSpan.Zero, stats.Elapsed);
         }
 
-        [Fact]
-        public void Ticker_WhenBodyReturnsValue_ValueIsAvailable()
         {
-            var ticker = Ticker
-                .WithPolicy(Policy.NoOp());
-
-            var stats = ticker.Execute(() => 1337);
-            Assert.Equal(1337, stats.Result);
-
-            stats = ticker.Execute(() => -9000);
-            Assert.Equal(-9000, stats.Result);
-
-            var boolStats = ticker.Execute(() => false);
-            Assert.False(boolStats.Result);
+            var stats = await ticker.ExecuteAsync(() => Task.FromResult(1701));
+            Assert.Equal(1701, stats.Result);
         }
+    }
 
-        [Fact]
-        public void Ticker_WhenPolicyHasKnownReturnType_PolicyCanBeUsed()
+    [Fact]
+    public void Ticker_ExecuteWithObserver_ObserverSeesStatistics()
+    {
+        var ticker = Ticker
+            .WithPolicy(Policy.NoOp());
+        var observer = new BookkeepingObserver();
+        var stats = ticker.Execute(() => { }, observer);
+
+        Assert.Equal(1, stats.Executions);
+        Assert.Equal(0, observer.Exceptions);
+        Assert.Equal(1, observer.Executions);
+        Assert.Equal(stats.Elapsed, observer.Elapsed);
+
+        stats = ticker.Execute(() => { throw new Exception(); }, observer);
+        Assert.Equal(1, stats.Executions);
+        Assert.Equal(1, observer.Exceptions);
+        Assert.Equal(2, observer.Executions);
+    }
+
+    [Fact]
+    public async Task Ticker_AsyncExecuteWithObserver_ObserverSeesStatistics()
+    {
+        var ticker = Ticker
+            .WithPolicy(Policy.NoOpAsync());
+        var observer = new BookkeepingObserver();
+
+        var stats = await ticker.ExecuteAsync(() => Task.CompletedTask, observer);
+
+        Assert.Equal(1, stats.Executions);
+        Assert.Equal(0, observer.Exceptions);
+        Assert.Equal(1, observer.Executions);
+        Assert.Equal(stats.Elapsed, observer.Elapsed);
+    }
+
+    [Fact]
+    public async Task Ticker_WithGlobalObserver_AllObserversAreNotified()
+    {
+        var global = new BookkeepingObserver();
+        var sync = new BookkeepingObserver();
+        var async = new BookkeepingObserver();
+
+        var ticker = Ticker
+            .WithPolicy(Policy.NoOp())
+            .WithObserver(global)
+            .WithObserver(sync);
+
+        var aticker = Ticker
+            .WithPolicy(Policy.NoOpAsync())
+            .WithObserver(global)
+            .WithObserver(async);
+
         {
-            var i = 100;
-            var policy = Policy
-                .HandleResult(100)
-                .Retry();
-            var ticker = Ticker
-                .WithPolicy(policy);
-
-            var stats1 = ticker.Execute(() => i++);
-            var stats2 = ticker.Execute(() => i++);
-
-            Assert.Equal(101, stats1.Result);
-            Assert.Equal(102, stats2.Result);
-        }
-
-        [Fact]
-        public async Task Ticker_WithAsyncBody_ExecutesBody()
-        {
-            var ticker = Ticker
-                .WithPolicy(Policy.NoOpAsync());
-
-            {
-                var stats = await ticker.ExecuteAsync(() => Task.Delay(100));
-                Assert.Equal(1, stats.Executions);
-                Assert.Equal(0, stats.Exceptions);
-                Assert.NotEqual(TimeSpan.Zero, stats.Elapsed);
-            }
-
-            {
-                var stats = await ticker.ExecuteAsync(() => Task.FromResult(1701));
-                Assert.Equal(1701, stats.Result);
-            }
-        }
-
-        [Fact]
-        public void Ticker_ExecuteWithObserver_ObserverSeesStatistics()
-        {
-            var ticker = Ticker
-                .WithPolicy(Policy.NoOp());
-            var observer = new BookkeepingObserver();
-            var stats = ticker.Execute(() => { }, observer);
-
-            Assert.Equal(1, stats.Executions);
-            Assert.Equal(0, observer.Exceptions);
-            Assert.Equal(1, observer.Executions);
-            Assert.Equal(stats.Elapsed, observer.Elapsed);
-
-            stats = ticker.Execute(() => { throw new Exception(); }, observer);
-            Assert.Equal(1, stats.Executions);
-            Assert.Equal(1, observer.Exceptions);
-            Assert.Equal(2, observer.Executions);
-        }
-
-        [Fact]
-        public async Task Ticker_AsyncExecuteWithObserver_ObserverSeesStatistics()
-        {
-            var ticker = Ticker
-                .WithPolicy(Policy.NoOpAsync());
-            var observer = new BookkeepingObserver();
-
-            var stats = await ticker.ExecuteAsync(() => Task.CompletedTask, observer);
-            
-            Assert.Equal(1, stats.Executions);
-            Assert.Equal(0, observer.Exceptions);
-            Assert.Equal(1, observer.Executions);
-            Assert.Equal(stats.Elapsed, observer.Elapsed);
-        }
-
-        [Fact]
-        public async Task Ticker_WithGlobalObserver_AllObserversAreNotified()
-        {
-            var global = new BookkeepingObserver();
-            var sync = new BookkeepingObserver();
-            var async = new BookkeepingObserver();
-
-            var ticker = Ticker
-                .WithPolicy(Policy.NoOp())
-                .WithObserver(global)
-                .WithObserver(sync);
-
-            var aticker = Ticker
-                .WithPolicy(Policy.NoOpAsync())
-                .WithObserver(global)
-                .WithObserver(async);
-            
-            {
-                var one = new BookkeepingObserver();
-                ticker.Execute(() => 1000, one);
-                await aticker.ExecuteAsync(() => Task.CompletedTask, one);
-                ticker.Execute(() => { throw new Exception(); });
-                await aticker.ExecuteAsync(() => Task.FromException(new Exception()));
-
-                Assert.Equal(2, one.Executions);
-                Assert.Equal(0, one.Exceptions);
-
-                Assert.Equal(4, global.Executions);
-                Assert.Equal(2, global.Exceptions);
-
-                Assert.Equal(2, sync.Executions);
-                Assert.Equal(1, sync.Exceptions);
-
-                Assert.Equal(2, async.Executions);
-                Assert.Equal(1, async.Exceptions);
-            }
-        }
-
-        [Fact]
-        public void Ticker_WhenExceptionIsThrown_ObserverIsNotified()
-        {
-            var global = new BookkeepingObserver();
             var one = new BookkeepingObserver();
-            var ex = new Exception("hello");
+            ticker.Execute(() => 1000, one);
+            await aticker.ExecuteAsync(() => Task.CompletedTask, one);
+            ticker.Execute(() => { throw new Exception(); });
+            await aticker.ExecuteAsync(() => Task.FromException(new Exception()));
 
-            var ticker = Ticker
-                .WithPolicy(Policy.NoOp())
-                .WithObserver(global);
+            Assert.Equal(2, one.Executions);
+            Assert.Equal(0, one.Exceptions);
 
-            ticker.Execute(() => 
-                    {
-                        throw ex;
-                    }, one);
-            
-            Assert.Equal(1, global.Exceptions);
-            Assert.Equal(1, global.Executions);
-            Assert.Equal(1, one.Exceptions);
-            Assert.Equal(1, one.Executions);
-            Assert.Equal(ex, global.LastException);
-            Assert.Equal(ex, one.LastException);
+            Assert.Equal(4, global.Executions);
+            Assert.Equal(2, global.Exceptions);
+
+            Assert.Equal(2, sync.Executions);
+            Assert.Equal(1, sync.Exceptions);
+
+            Assert.Equal(2, async.Executions);
+            Assert.Equal(1, async.Exceptions);
         }
+    }
 
-        [Fact]
-        public async Task Ticker_ExecuteWithCancellationToken_StopsExecution()
+    [Fact]
+    public void Ticker_WhenExceptionIsThrown_ObserverIsNotified()
+    {
+        var global = new BookkeepingObserver();
+        var one = new BookkeepingObserver();
+        var ex = new Exception("hello");
+
+        var ticker = Ticker
+            .WithPolicy(Policy.NoOp())
+            .WithObserver(global);
+
+        ticker.Execute(() =>
+                {
+                    throw ex;
+                }, one);
+
+        Assert.Equal(1, global.Exceptions);
+        Assert.Equal(1, global.Executions);
+        Assert.Equal(1, one.Exceptions);
+        Assert.Equal(1, one.Executions);
+        Assert.Equal(ex, global.LastException);
+        Assert.Equal(ex, one.LastException);
+    }
+
+    [Fact]
+    public async Task Ticker_ExecuteWithCancellationToken_StopsExecution()
+    {
+        var ticker = Ticker.WithPolicy(Policy.NoOpAsync());
+        var cts = new CancellationTokenSource();
+
+        var exTask = ticker.ExecuteAsync(ct => Task.Delay(TimeSpan.FromSeconds(5), ct), cts.Token);
+        Assert.False(exTask.IsCompleted);
+        cts.Cancel();
+        var res = await exTask;
+    }
+
+    [Fact]
+    public void Ticker_ExecuteNoCapture_ReturnsDelegateResult()
+    {
+        var global = new BookkeepingObserver();
+        var ticker = Ticker.WithPolicy(Policy.NoOp<int>())
+            .WithObserver(global);
+        var local = new BookkeepingObserver();
+
+        var result = ticker.ExecuteNoCapture(() => 223, local);
+
+        Assert.Equal(223, result);
+        Assert.Equal(1, local.Executions);
+        Assert.Equal(1, global.Executions);
+        Assert.Equal(0, local.Exceptions);
+        Assert.Equal(0, global.Exceptions);
+        Assert.True(local.Elapsed > TimeSpan.Zero);
+        Assert.True(global.Elapsed > TimeSpan.Zero);
+        Assert.Equal(local.Elapsed, global.Elapsed);
+    }
+
+    [Fact]
+    public void Ticker_ExecuteNoCaptureWithException_ExceptionIsReported()
+    {
+        var global = new BookkeepingObserver();
+        var ticker = Ticker.WithPolicy(Policy.NoOp<double>())
+            .WithObserver(global);
+        var local = new BookkeepingObserver();
+
+        Assert.Throws<Exception>(() =>
+                {
+                    ticker.ExecuteNoCapture(() => throw new Exception(), local);
+                });
+
+        Assert.Equal(1, local.Executions);
+        Assert.Equal(1, global.Executions);
+        Assert.Equal(1, local.Exceptions);
+        Assert.Equal(1, global.Exceptions);
+        Assert.NotNull(global.LastException);
+        Assert.NotNull(local.LastException);
+        Assert.True(local.Elapsed > TimeSpan.Zero);
+        Assert.True(global.Elapsed > TimeSpan.Zero);
+        Assert.Equal(local.Elapsed, global.Elapsed);
+    }
+
+    [Fact]
+    public async Task Ticker_ExecuteNoCaptureAsync_StatisticsAreReported()
+    {
+        var global = new BookkeepingObserver();
+        var ticker = Ticker.WithPolicy(Policy.NoOpAsync<int>())
+            .WithObserver(global);
+        var local = new BookkeepingObserver();
+
+        var result = await ticker.ExecuteNoCaptureAsync(() => Task.FromResult(100), local);
+        var cts = new CancellationTokenSource(100);
+        await Assert.ThrowsAsync<TaskCanceledException>(() =>
+                {
+                    return ticker.ExecuteNoCaptureAsync(async t =>
+                            {
+                                await Task.Delay(10_000, t);
+                                return 100;
+                            }, local, cts.Token);
+                });
+
+        Assert.Equal(2, local.Executions);
+        Assert.Equal(2, global.Executions);
+        Assert.Equal(1, local.Exceptions);
+        Assert.Equal(1, global.Exceptions);
+        Assert.True(local.Elapsed > TimeSpan.Zero);
+        Assert.True(global.Elapsed > TimeSpan.Zero);
+        Assert.Equal(local.Elapsed, global.Elapsed);
+        Assert.IsType<TaskCanceledException>(local.LastException);
+        Assert.IsType<TaskCanceledException>(global.LastException);
+    }
+
+    [Fact]
+    public void Ticker_ExecuteUntypedPolicyNoCapture_StatistcsAreReported()
+    {
+        var global = new BookkeepingObserver();
+        var ticker = Ticker.WithPolicy(Policy.NoOp())
+            .WithObserver(global);
+        var local = new BookkeepingObserver();
+        var zero = 1 - 1;
+
+        var result = ticker.ExecuteNoCapture(() => 19534, local);
+        Assert.Throws<DivideByZeroException>(() =>
+                {
+                    ticker.ExecuteNoCapture(() => checked(100 / zero), local);
+                });
+
+        Assert.Equal(2, local.Executions);
+        Assert.Equal(2, global.Executions);
+        Assert.Equal(1, local.Exceptions);
+        Assert.Equal(1, global.Exceptions);
+        Assert.True(local.Elapsed > TimeSpan.Zero);
+        Assert.True(global.Elapsed > TimeSpan.Zero);
+        Assert.Equal(local.Elapsed, global.Elapsed);
+        Assert.IsType<DivideByZeroException>(local.LastException);
+        Assert.IsType<DivideByZeroException>(global.LastException);
+    }
+
+    [Fact]
+    public async Task Ticker_ExecuteUntypedPolicyNoCaptureAsync_StatisticsAreReported()
+    {
+        var global = new BookkeepingObserver();
+        var ticker = Ticker.WithPolicy(Policy.NoOpAsync())
+            .WithObserver(global);
+        var local = new BookkeepingObserver();
+        var run = false;
+
+        await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+                {
+                    var cts = new CancellationTokenSource(100);
+                    await ticker.ExecuteNoCaptureAsync(async ct =>
+                            {
+                                await Task.Delay(10_000, ct);
+                            }, local, cts.Token);
+                });
+        await ticker.ExecuteNoCaptureAsync(() =>
         {
-            var ticker = Ticker.WithPolicy(Policy.NoOpAsync());
-            var cts = new CancellationTokenSource();
-            
-            var exTask = ticker.ExecuteAsync(ct => Task.Delay(TimeSpan.FromSeconds(5), ct), cts.Token);
-            Assert.False(exTask.IsCompleted);
-            cts.Cancel();
-            var res = await exTask;
-        }
+            run = true;
+            return Task.CompletedTask;
+        },
+            local);
 
-        [Fact]
-        public void Ticker_ExecuteNoCapture_ReturnsDelegateResult()
-        {
-            var global = new BookkeepingObserver();
-            var ticker = Ticker.WithPolicy(Policy.NoOp<int>())
-                .WithObserver(global);
-            var local = new BookkeepingObserver();
+        Assert.True(run);
+        Assert.Equal(2, local.Executions);
+        Assert.Equal(2, global.Executions);
+        Assert.Equal(1, local.Exceptions);
+        Assert.Equal(1, global.Exceptions);
+        Assert.True(local.Elapsed > TimeSpan.Zero);
+        Assert.True(global.Elapsed > TimeSpan.Zero);
+        Assert.Equal(local.Elapsed, global.Elapsed);
+        Assert.IsType<TaskCanceledException>(local.LastException);
+        Assert.IsType<TaskCanceledException>(global.LastException);
+    }
 
-            var result = ticker.ExecuteNoCapture(() => 223, local);
+    [Fact]
+    public async Task Ticker_WhenExceptionIsCaptured_ExposedOnStatistics()
+    {
+        var ticker = Ticker.WithPolicy(Policy.NoOpAsync());
 
-            Assert.Equal(223, result);
-            Assert.Equal(1, local.Executions);
-            Assert.Equal(1, global.Executions);
-            Assert.Equal(0, local.Exceptions);
-            Assert.Equal(0, global.Exceptions);
-            Assert.True(local.Elapsed > TimeSpan.Zero);
-            Assert.True(global.Elapsed > TimeSpan.Zero);
-            Assert.Equal(local.Elapsed, global.Elapsed);
-        }
+        var stats = await ticker.ExecuteAsync(() => Task.FromException(new Exception("test_exception")));
 
-        [Fact]
-        public void Ticker_ExecuteNoCaptureWithException_ExceptionIsReported()
-        {
-            var global = new BookkeepingObserver();
-            var ticker = Ticker.WithPolicy(Policy.NoOp<double>())
-                .WithObserver(global);
-            var local = new BookkeepingObserver();
-
-            Assert.Throws<Exception>(() =>
-                    {
-                        ticker.ExecuteNoCapture(() => throw new Exception(), local);
-                    });
-
-            Assert.Equal(1, local.Executions);
-            Assert.Equal(1, global.Executions);
-            Assert.Equal(1, local.Exceptions);
-            Assert.Equal(1, global.Exceptions);
-            Assert.NotNull(global.LastException);
-            Assert.NotNull(local.LastException);
-            Assert.True(local.Elapsed > TimeSpan.Zero);
-            Assert.True(global.Elapsed > TimeSpan.Zero);
-            Assert.Equal(local.Elapsed, global.Elapsed);
-        }
-
-        [Fact]
-        public async Task Ticker_ExecuteNoCaptureAsync_StatisticsAreReported()
-        {
-            var global = new BookkeepingObserver();
-            var ticker = Ticker.WithPolicy(Policy.NoOpAsync<int>())
-                .WithObserver(global);
-            var local = new BookkeepingObserver();
-
-            var result = await ticker.ExecuteNoCaptureAsync(() => Task.FromResult(100), local);
-            var cts = new CancellationTokenSource(100);
-            await Assert.ThrowsAsync<TaskCanceledException>(() =>
-                    {
-                        return ticker.ExecuteNoCaptureAsync(async t =>
-                                {
-                                    await Task.Delay(10_000, t);
-                                    return 100;
-                                }, local, cts.Token);
-                    });
-
-            Assert.Equal(2, local.Executions);
-            Assert.Equal(2, global.Executions);
-            Assert.Equal(1, local.Exceptions);
-            Assert.Equal(1, global.Exceptions);
-            Assert.True(local.Elapsed > TimeSpan.Zero);
-            Assert.True(global.Elapsed > TimeSpan.Zero);
-            Assert.Equal(local.Elapsed, global.Elapsed);
-            Assert.IsType<TaskCanceledException>(local.LastException);
-            Assert.IsType<TaskCanceledException>(global.LastException);
-        }
-
-        [Fact]
-        public void Ticker_ExecuteUntypedPolicyNoCapture_StatistcsAreReported()
-        {
-            var global = new BookkeepingObserver();
-            var ticker = Ticker.WithPolicy(Policy.NoOp())
-                .WithObserver(global);
-            var local = new BookkeepingObserver();
-            var zero = 1 - 1;
-
-            var result = ticker.ExecuteNoCapture(() => 19534, local);
-            Assert.Throws<DivideByZeroException>(() =>
-                    {
-                        ticker.ExecuteNoCapture(() => checked(100 / zero), local);
-                    });
-
-            Assert.Equal(2, local.Executions);
-            Assert.Equal(2, global.Executions);
-            Assert.Equal(1, local.Exceptions);
-            Assert.Equal(1, global.Exceptions);
-            Assert.True(local.Elapsed > TimeSpan.Zero);
-            Assert.True(global.Elapsed > TimeSpan.Zero);
-            Assert.Equal(local.Elapsed, global.Elapsed);
-            Assert.IsType<DivideByZeroException>(local.LastException);
-            Assert.IsType<DivideByZeroException>(global.LastException);
-        }
-
-        [Fact]
-        public async Task Ticker_ExecuteUntypedPolicyNoCaptureAsync_StatisticsAreReported()
-        {
-            var global = new BookkeepingObserver();
-            var ticker = Ticker.WithPolicy(Policy.NoOpAsync())
-                .WithObserver(global);
-            var local = new BookkeepingObserver();
-            var run = false;
-
-            await Assert.ThrowsAsync<TaskCanceledException>(async () =>
-                    {
-                        var cts = new CancellationTokenSource(100);
-                        await ticker.ExecuteNoCaptureAsync(async ct =>
-                                {
-                                    await Task.Delay(10_000, ct);
-                                }, local, cts.Token);
-                    });
-            await ticker.ExecuteNoCaptureAsync(() => {
-                    run = true;
-                    return Task.CompletedTask;
-                },
-                local);
-
-            Assert.True(run);
-            Assert.Equal(2, local.Executions);
-            Assert.Equal(2, global.Executions);
-            Assert.Equal(1, local.Exceptions);
-            Assert.Equal(1, global.Exceptions);
-            Assert.True(local.Elapsed > TimeSpan.Zero);
-            Assert.True(global.Elapsed > TimeSpan.Zero);
-            Assert.Equal(local.Elapsed, global.Elapsed);
-            Assert.IsType<TaskCanceledException>(local.LastException);
-            Assert.IsType<TaskCanceledException>(global.LastException);
-        }
-
-        [Fact]
-        public async Task Ticker_WhenExceptionIsCaptured_ExposedOnStatistics()
-        {
-            var ticker = Ticker.WithPolicy(Policy.NoOpAsync());
-
-            var stats = await ticker.ExecuteAsync(() => Task.FromException(new Exception("test_exception")));
-
-            Assert.NotNull(stats.FinalException);
-            Assert.Equal("test_exception", stats.FinalException.Message);
-        }
+        Assert.NotNull(stats.FinalException);
+        Assert.Equal("test_exception", stats.FinalException.Message);
     }
 }


### PR DESCRIPTION
Get rid of stopwatch allocations from the track functions. This should provide
some small reduction in GC pressure.